### PR TITLE
Decouple panning selfvolume

### DIFF
--- a/classes/AutoPanMix.sc
+++ b/classes/AutoPanMix.sc
@@ -111,7 +111,7 @@ AutoPanMix : BaseMix {
 			var client = \client.ir(0);
 
 			// create an array containing all audio input channels for a specific client
-			var mix = Array.fill(2, { arg channelNum;
+			var mix = Array.fill(inputChannelsPerClient, { arg channelNum;
 				// start with the raw audio input
 				var in = SoundIn.ar((client*inputChannelsPerClient)+channelNum);
 

--- a/classes/AutoPanMix.sc
+++ b/classes/AutoPanMix.sc
@@ -292,7 +292,7 @@ AutoPanMix : BaseMix {
 					var node = Synth("jacktrip_simple_in", [\client, clientNum, \out, b], g, \addToTail);
 					("Created synth" + "jacktrip_simple_in" + node.nodeID + "on bus" + b.index).postln;
 				};
-			})
+			});
 
 			g = 200;
 


### PR DESCRIPTION
    Updated synth names to remove "autopan" where they are unrelated to panning.
    This is in anticipation of future renaming and refactoring.

    Added a jacktrip_simple_in which is used to bring audio into the input
    busses, without panning

    Added an autopan boolean parameter, which is used to toggle between
    automated panning and downmixing client channels to mono.
