### PR TITLE
Mike decompose sc

### DIFF
--- a/examples/MajorChord.scd
+++ b/examples/MajorChord.scd
@@ -1,3 +1,19 @@
+/* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * MajorChord.scd
  *
@@ -8,6 +24,7 @@
  * harmonics to make it a major chord. Plays a beep when first
  * executed.
  */
+
 
 // output to allChannels
 // change this array to only send metronome sounds to specific clients

--- a/examples/Metronome.scd
+++ b/examples/Metronome.scd
@@ -1,3 +1,19 @@
+/* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 /*
  * Metronome.scd
  *
@@ -8,7 +24,6 @@
  * 
  * Change the default BPM value below to change the metronome rate
  */
-
 
 // Metronome rate in BPM
 ~rate = 90;

--- a/examples/TuningNote.scd
+++ b/examples/TuningNote.scd
@@ -1,3 +1,19 @@
+/* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 /*
  * TuningNote.scd
  *

--- a/lib/AggregateLink.sc
+++ b/lib/AggregateLink.sc
@@ -1,3 +1,19 @@
+/* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
 /*
  * Aggregate Link: Performs a reduction on the input signal.
  *
@@ -21,6 +37,7 @@
  * More information on how this works can be found under the Multichannel
  * Expansion article in the SC docs and in the docs for the Mix class.
  */
+
 AggregateLink : Link {
     *new {
 		^super.new();

--- a/lib/BandPassFilterLink.sc
+++ b/lib/BandPassFilterLink.sc
@@ -1,7 +1,24 @@
 /* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* 
  * BandPassFilterLink: applies a low-pass
  * and high-pass filter to a signal.
  */
+
 BandPassFilterLink : Link {
     var<> low;
     var<> high;

--- a/lib/JackTripInput.sc
+++ b/lib/JackTripInput.sc
@@ -1,3 +1,19 @@
+/* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * JackTripInput: Reads inputs given the number of clients and the number
  * of input channels per client.
@@ -24,6 +40,7 @@
  * Since these array elements are all UGens, the calling function can take advantage of
  * Supercollider's Multichannel Expansion functionality to process many signals at once.
  */
+
 JackTripInput : Class {
 
     var<> numClients;

--- a/lib/Link.sc
+++ b/lib/Link.sc
@@ -1,3 +1,19 @@
+/* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * Link: A stage in a signal flow chain.
  *
@@ -26,6 +42,7 @@
  * Additionally, transformations may invoke multichannel expansion, depending
  * on the parameters and input signals.
  */
+
 Link : Class {
     *new {
 		^super.new();

--- a/lib/MultiplyLink.sc
+++ b/lib/MultiplyLink.sc
@@ -1,10 +1,27 @@
 /* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* 
  * MultiplyLink: multiplies a signal by a provided factor.
  *
  * If the input signal and the factor are arrays of the same dimension, then
  * multichannel expansion will be invoked and the factor array can be thought
  * of as an array of weights.
  */
+
 MultiplyLink : Link {
     var<> factor;
 

--- a/lib/PanningLink.sc
+++ b/lib/PanningLink.sc
@@ -17,4 +17,28 @@ PanningLink : Link {
         signal = Pan2.ar(input, pan);
         ^signal;
     }
+
+    // returns an array of initial pan values for each client, from -1 to 1
+    *autoPan { | maxClients, slots |
+        var panValues;
+
+        // automatically pan clients across stereo field
+        if (slots > maxClients, { slots = maxClients; });
+        if (slots < 2, {
+            panValues = [0];
+            slots = 1;
+        }, {
+            // LinLin maps a range of input values linearly to a range of
+            // output values
+            panValues = Array.fill(slots, { arg i;
+                LinLin.kr((i % slots) + 1, 0, slots + 1, -1, 1);
+            });
+        });
+
+        ("panning" + maxClients + "clients across" + slots + "slots:" + panValues).postln;
+
+        ^Array.fill(maxClients, { arg i;
+            panValues[i % slots];
+        });
+    }
 }

--- a/lib/PanningLink.sc
+++ b/lib/PanningLink.sc
@@ -1,10 +1,27 @@
 /* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* 
  * PanningLink: pans a signal across a stereo field.
  *
  * If the input signal and the pan value are arrays of the same dimension, then
  * multichannel expansion will be invoked and each channel will be panned according
  * the corresponding value in the pan array.
  */
+
 PanningLink : Link {
     var<> pan;
 

--- a/lib/SquashToMonoLink.sc
+++ b/lib/SquashToMonoLink.sc
@@ -1,3 +1,19 @@
+/* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * SquashToMonoLink: Squashes a signal to mono audio.
  *
@@ -11,6 +27,7 @@
  *      If keepChannels is true, the output is [sum, sum].
  *      If false, the output is just sum.
  */
+
 SquashToMonoLink : Link {
 
     var <> nested;

--- a/mixers/AutoPanMix/AutoPanMix.sc
+++ b/mixers/AutoPanMix/AutoPanMix.sc
@@ -244,29 +244,7 @@ AutoPanMix : BaseMix {
 			if (autopan, {
 
 				var node;
-				var pSlots = panSlots;
-				var panValues;
-				var p;
-
-				// automatically pan clients across stereo field
-				if (pSlots > maxClients, { pSlots = maxClients; });
-				if (pSlots < 2, {
-					panValues = [0];
-					pSlots = 1;
-				}, {
-					// LinLin maps a range of input values linearly to a range of
-					// output values
-					panValues = Array.fill(pSlots, { arg i;
-						LinLin.kr((i % pSlots) + 1, 0, pSlots + 1, -1, 1);
-					});
-					panValues = [-1, 1];
-				});
-
-				("panning clients across" + pSlots + "slots:" + panValues).postln;
-
-				p = Array.fill(maxClients, { arg i;
-					panValues[i % pSlots];
-				});
+				var p = PanningLink.autoPan(maxClients, panSlots);
 
 				// Squash the clients tracks to mono, then pan them before they reach
 				// the input buses.

--- a/mixers/AutoPanMix/AutoPanMix.sc
+++ b/mixers/AutoPanMix/AutoPanMix.sc
@@ -177,7 +177,7 @@ AutoPanMix : BaseMix {
 		 */
 		"Sending SynthDef: jamulus_simple_out".postln;
 		SynthDef("jamulus_simple_out", {
-			var in, signal, volumeOpt;
+			var signal;
 			var mix = \mix.kr(defaultMix) * \mul.kr(masterVolume);
 
 			mix[0] = 0;

--- a/mixers/AutoPanMix/makeInputBusses.scd
+++ b/mixers/AutoPanMix/makeInputBusses.scd
@@ -1,0 +1,30 @@
+/* 
+ * Copyright 2020-2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// allocate a stereo audio bus the handle input from each client
+// the first maxClients * outputChannelsPerClient channels are reserved for audio outputs
+// the subsequent maxClients * inputChannelsPerClient channels are reserved for audio inputs
+// audio is read from the audio input channels and is sent back to each client through the
+// audio output channels
+// private buses are reserved for internally routing audio signals
+
+~makeInputBusses = { | server, maxClients, inputChannelsPerClient, outputChannelsPerClient |
+	~firstPrivateBus = (maxClients * (inputChannelsPerClient + outputChannelsPerClient));
+	~inputBuses = Array.fill(maxClients, { |n|
+		var i = ~firstPrivateBus + (n * inputChannelsPerClient);
+		Bus.new('audio', i, inputChannelsPerClient, server);
+	});
+}

--- a/mixers/AutoPanMix/synthDefs.scd
+++ b/mixers/AutoPanMix/synthDefs.scd
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+~synthDefs = (
+
+	/*
+	 * JackTripSimpleIn is used to apply leveling and filters to a specific client input, 
+	 * and send it to an audio bus
+	 *
+	 * \low : low frequency to use for bandpass filter (default 20)
+	 * \high : high frequency to use for bandpass filter (default 20000)
+	 * \mul : amplitude level multiplier (default 1.0)
+	 */
+	JackTripSimpleIn: { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
+		var signal;
+
+		signal = JackTripInput(maxClients, inputChannelsPerClient).getSignal();
+		signal = BandPassFilterLink(\low.kr(20), \high.kr(20000)).transform(signal);
+		signal = MultiplyLink(\mul.kr(1)).transform(signal);
+
+		signal.do({ arg item, i;
+			Out.ar(~inputBuses[i].index, item);
+		});
+	},
+
+	/*
+	 * JackTripPannedIn is used to apply leveling, filters and panning to a specific client input, 
+	 * and send it to an audio bus
+	 *
+	 * \low : frequency to use for lowpass filter (default 20)
+	 * \high : frequency to use for bandpass filter (default 20000)
+	 * \mul : amplitude level multiplier (default 1.0)
+	 */
+	JackTripPannedIn: { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
+		var signal;
+		var defaultPan = 0 ! maxClients;
+
+		signal = JackTripInput(maxClients, inputChannelsPerClient).getSignal();
+		signal = BandPassFilterLink(\low.kr(20), \high.kr(20000)).transform(signal);
+		signal = SquashToMonoLink(true, false).transform(signal);
+		signal = PanningLink(\pan.kr(defaultPan)).transform(signal);
+		signal = MultiplyLink(\mul.kr(1)).transform(signal);
+
+		signal.do({ arg item, i;
+			Out.ar(~inputBuses[i].index, item);
+		});
+	},
+
+	/*
+	 * JackTripPersonalMixOut is used to create a personal mix by combining output from the input buses
+	 *
+	 * \mul : amplitude level multiplier (default 1.0)
+	 */
+	JackTripPersonalMixOut: { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
+		var personalMixes = \mix.kr(1 ! (maxClients * maxClients));
+
+		maxClients.do({ arg clientNum;
+			var signal = JackTripInput(maxClients, outputChannelsPerClient, false, ~firstPrivateBus).getSignal();
+			var m = Array.fill(maxClients, { arg n;
+				personalMixes[(clientNum * maxClients) + n];
+			});
+		
+			var s = MultiplyLink(m * \mul.kr(1)).transform(signal);
+			s = AggregateLink().transform(s);
+		
+			Out.ar(outputChannelsPerClient * clientNum, s);
+		});
+
+	},
+
+	/*
+	* JackTripSimpleMix: a minimal mix that scales well
+	*
+	* \maxClients: maximum number of clients that may connect to the audio server
+	* \inputChannelsPerClient: number of input channels received from each client
+	* \outputChannelsPerClient: number of output channels sent to each client
+	* \withJamulus: create mixes adapted Jamulus being connected on channels 1 & 2
+	* \mix : array of amplitude level multipliers (default 1.0) for each client
+	* \mul : master amplitude level multiplier (default 1.0)
+	*/
+	JackTripSimpleMix: { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
+		// TODO: replace reuse the definition inside of SimpleMix instead
+		var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
+		if (withJamulus, {
+			var jackTripSignal = JackTripInput(maxClients - 1, inputChannelsPerClient, true, (~firstPrivateBus + inputChannelsPerClient)).getSignal();
+			var jamulusSignal = JackTripInput(1, inputChannelsPerClient, true, ~firstPrivateBus).getSignal();
+			~aggregateAndSendToAll.value(jackTripSignal, levels, maxClients, outputChannelsPerClient);
+			~sendFirstToEveryoneElse.value(jamulusSignal, levels, maxClients, outputChannelsPerClient);
+		}, {
+			var jackTripSignal = JackTripInput(maxClients, inputChannelsPerClient, true, ~firstPrivateBus).getSignal();
+			~aggregateAndSendToAll.value(jackTripSignal, levels, maxClients, outputChannelsPerClient);
+		});
+	}	
+);

--- a/mixers/BaseMix.sc
+++ b/mixers/BaseMix.sc
@@ -11,12 +11,13 @@ BaseMix : Object {
 	var <>serverPort = 57110;		// port number of remote audio server (default SC port)
 	var <>serverReady, <>server;    // state of the server and the server object
 	var <>mixStarted;				// Condition object used to pause execution until the server is ready
+	var <>defaultMix;				// default master mix is just an array of ones (do nothing)
 	classvar inputChannelsPerClient = 2;	// for stereo audio inputs
 	classvar outputChannelsPerClient = 2;	// for stereo audio outputs
 
 	// create a new instance
 	*new { | maxClients = 16 |
-		^super.newCopyArgs(maxClients).serverReady_(Condition.new).mixStarted_(Condition.new);
+		^super.newCopyArgs(maxClients).serverReady_(Condition.new).mixStarted_(Condition.new).defaultMix_(1 ! maxClients);
 	}
 
 	// connect to a remote server

--- a/mixers/BaseMix.sc
+++ b/mixers/BaseMix.sc
@@ -1,8 +1,25 @@
+/* 
+ * Copyright 2020-2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * BaseMix: base class for other JackTrip Virtual Studio mixers
  *
  * \maxClients: maximum number of clients that may connect to the audio server
  */
+ 
 BaseMix : Object {
 	var <>maxClients;
 	var <>withJamulus = false;		// create mixes adapted Jamulus being connected on channels 1 & 2
@@ -56,6 +73,7 @@ BaseMix : Object {
 	sendSynthDefs { | filename |
 		filename.load;
 		~synthDefs.keysValuesDo{ | name, f |
+			("Sending SynthDef:"+name).postln;
 			SynthDef(name, {
 				SynthDef.wrap(f, prependArgs: [maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus]);
 			}).send();

--- a/mixers/BaseMix.sc
+++ b/mixers/BaseMix.sc
@@ -19,10 +19,10 @@
  *
  * \maxClients: maximum number of clients that may connect to the audio server
  */
- 
+
 BaseMix : Object {
 	var <>maxClients;
-	var <>withJamulus = false;		// create mixes adapted Jamulus being connected on channels 1 & 2
+	var <>withJamulus = true;		// create mixes adapted Jamulus being connected on channels 1 & 2
 	var <>masterVolume = 1.0;		// master volume level multiplier
 	var <>serverIp = "127.0.0.1";	// IP address or hostname of remote audio server
 	var <>serverPort = 57110;		// port number of remote audio server (default SC port)

--- a/mixers/BaseMix.sc
+++ b/mixers/BaseMix.sc
@@ -52,6 +52,16 @@ BaseMix : Object {
 		server.doWhenBooted({waitForServer.value});
 	}
 
+	// sendSynthDefs method sends definitions from a file to the server for use in audio mixing
+	sendSynthDefs { | filename |
+		filename.load;
+		~synthDefs.keysValuesDo{ | name, f |
+			SynthDef(name, {
+				SynthDef.wrap(f, prependArgs: [maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus]);
+			}).send();
+		};
+	}
+
 	// wait for mix to start
 	// mixStarted is the Condition object and pauses execution until
 	// the value is set to true and mixStarted is signalled

--- a/mixers/BaseMix.sc
+++ b/mixers/BaseMix.sc
@@ -5,6 +5,7 @@
  */
 BaseMix : Object {
 	var <>maxClients;
+	var <>withJamulus = false;		// create mixes adapted Jamulus being connected on channels 1 & 2
 	var <>masterVolume = 1.0;		// master volume level multiplier
 	var <>serverIp = "127.0.0.1";	// IP address or hostname of remote audio server
 	var <>serverPort = 57110;		// port number of remote audio server (default SC port)
@@ -27,8 +28,8 @@ BaseMix : Object {
 
 			// Make 10 attempts to connect to the server
 			{retries > 0}.while({
-				server.serverRunning.postln;
-				Server.allRunningServers.postln;
+				//server.serverRunning.postln;
+				//Server.allRunningServers.postln;
 				if (Server.allRunningServers != [], {
 					"Server started".postln;
 					retries = 0;

--- a/mixers/SimpleMix/SimpleMix.sc
+++ b/mixers/SimpleMix/SimpleMix.sc
@@ -1,3 +1,19 @@
+/* 
+ * Copyright 2020-2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * SimpleMix: a minimal mix that scales well
  *
@@ -5,6 +21,7 @@
  * \serverIp: IP address or hostname of remote audio server
  * \serverPort: port number of remote audio server
  */
+ 
 SimpleMix : BaseMix {
 
 	// create a new instance

--- a/mixers/SimpleMix/SimpleMix.sc
+++ b/mixers/SimpleMix/SimpleMix.sc
@@ -14,8 +14,6 @@ SimpleMix : BaseMix {
 
 	// sendSynthDefs method sends definitions to the server for use in audio mixing
 	sendSynthDefs {
-		// default master mix does nothing
-		var defaultMix = 1 ! maxClients;
 
 		/*
 		* jacktrip_simple_mix is used to create a simple master max.

--- a/mixers/SimpleMix/aggregateAndSendToAll.scd
+++ b/mixers/SimpleMix/aggregateAndSendToAll.scd
@@ -1,3 +1,19 @@
+/* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * aggregateAndSendToAll: aggregates an array of input signals, adjust levels,
  * and sends audio to all clients

--- a/mixers/SimpleMix/aggregateAndSendToAll.scd
+++ b/mixers/SimpleMix/aggregateAndSendToAll.scd
@@ -1,0 +1,23 @@
+/*
+ * aggregateAndSendToAll: aggregates an array of input signals, adjust levels,
+ * and sends audio to all clients
+ *
+ * \in: array of input audio channels to aggregate together
+ * \levels : array of amplitude level multipliers (default 1.0) for each client
+ * \maxClients: maximum number of clients that may connect to the audio server
+ * \outputChannelsPerClient: number of output channels sent to each client
+ */
+
+~aggregateAndSendToAll = { | in, levels, maxClients, outputChannelsPerClient = 2 |
+	var out;
+
+	// adjust levels and aggregate JackTrip signal
+	var signal = MultiplyLink(levels).transform(in);
+	signal = AggregateLink().transform(signal);
+
+	// send JackTrip signals to all outputs (including Jamulus)
+	out = Array.fill(maxClients, { arg n;
+		n * outputChannelsPerClient;
+	});
+	Out.ar(out, signal);
+};

--- a/mixers/SimpleMix/sendFirstToEveryoneElse.scd
+++ b/mixers/SimpleMix/sendFirstToEveryoneElse.scd
@@ -1,3 +1,19 @@
+/* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /*
  * sendFirstToEveryoneElse: sends the input audio channels from the first
  * client to all other clients

--- a/mixers/SimpleMix/sendFirstToEveryoneElse.scd
+++ b/mixers/SimpleMix/sendFirstToEveryoneElse.scd
@@ -1,0 +1,22 @@
+/*
+ * sendFirstToEveryoneElse: sends the input audio channels from the first
+ * client to all other clients
+ *
+ * \in: array of input audio channels to aggregate together
+ * \levels : array of amplitude level multipliers (default 1.0) for each client
+ * \maxClients: maximum number of clients that may connect to the audio server
+ * \outputChannelsPerClient: number of output channels sent to each client
+ */
+ 
+~sendFirstToEveryoneElse = { | in, levels, maxClients, outputChannelsPerClient = 2 |
+	var out;
+
+	// adjust levels
+	var signal = MultiplyLink(levels).transform(in);
+
+	// send Jamulus signal to JackTrip outputs
+	out = Array.fill(maxClients - 1, { arg n;
+		(n + 1) * outputChannelsPerClient;
+	});
+	Out.ar(out, signal[0]);
+};

--- a/mixers/SimpleMix/synthDefs.scd
+++ b/mixers/SimpleMix/synthDefs.scd
@@ -1,0 +1,29 @@
+"aggregateAndSendToAll.scd".loadRelative;
+"sendFirstToEveryoneElse.scd".loadRelative;
+
+~synthDefs = (
+
+	/*
+	* JackTripSimpleMix: a minimal mix that scales well
+	*
+	* \maxClients: maximum number of clients that may connect to the audio server
+	* \inputChannelsPerClient: number of input channels received from each client
+	* \outputChannelsPerClient: number of output channels sent to each client
+	* \withJamulus: create mixes adapted Jamulus being connected on channels 1 & 2
+	* \mix : array of amplitude level multipliers (default 1.0) for each client
+	* \mul : master amplitude level multiplier (default 1.0)
+	*/
+	JackTripSimpleMix: { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
+		var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
+		if (withJamulus, {
+			var jackTripSignal = JackTripInput(maxClients - 1, inputChannelsPerClient, true, inputChannelsPerClient).getSignal();
+			var jamulusSignal = JackTripInput(1, inputChannelsPerClient, true, 0).getSignal();
+			~aggregateAndSendToAll.value(jackTripSignal, levels, maxClients, outputChannelsPerClient);
+			~sendFirstToEveryoneElse.value(jamulusSignal, levels, maxClients, outputChannelsPerClient);
+		}, {
+			var jackTripSignal = JackTripInput(maxClients, inputChannelsPerClient).getSignal();
+			~aggregateAndSendToAll.value(jackTripSignal, levels, maxClients, outputChannelsPerClient);
+		});
+	}
+
+);

--- a/mixers/SimpleMix/synthDefs.scd
+++ b/mixers/SimpleMix/synthDefs.scd
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 "aggregateAndSendToAll.scd".loadRelative;
 "sendFirstToEveryoneElse.scd".loadRelative;
 


### PR DESCRIPTION
    Updated personalmix input synth to accept mix parameter which is
    an array of the concatenation of all personal mixes. Also added
    pan parameter which is an array of pan positions.

    Only multiply output signals by masterVolume, and make this a
    parameter controllable via OSC.

    Updates to get autopanmix gui to work again.

    Added withJamulus parameter to BaseMix, which defaults to true.
    This enables us to modify the logic for synths to account for the
    first two input and output channels being used by Jamulus, versus
    using all channels for JackTrip. This makes it a lot easier to test
    things locally when you only have 2 in/out channels on your computer.

    Modified SimpleMix logic to only use a single synth, with behavior
    modified depending on whether or not Jamulus is enabled.
