### PR TITLE
Added JackTripSimpleMixFromBus synthdef to allow sharing of code

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ setting `serverIp`.
 
 * `wait`: this will block until the mixer has started processing audio.
 
-* `runAfter`: this can be used to provide a function that is executed after
+* `after`: this can be used to provide a function that is executed after
 the mixer has started processing audio.
 
 By convention, mixers should also implement a `start` method which starts

--- a/functions/jackTripSimpleMix.scd
+++ b/functions/jackTripSimpleMix.scd
@@ -24,21 +24,22 @@
  * \inputChannelsPerClient: number of input channels received from each client
  * \outputChannelsPerClient: number of output channels sent to each client
  * \withJamulus: create mixes adapted Jamulus being connected on channels 1 & 2
+ * \useSoundIn: if true, use SoundIn() for input channels; otherwise, use In()
  * \offset: input channel offset used for reading audio input
  * \mix : array of amplitude level multipliers (default 1.0) for each client
  * \mul : master amplitude level multiplier (default 1.0)
  */
 
-~jackTripSimpleMix = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false, offset = 0 |
+~jackTripSimpleMix = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false, useSoundIn = true, offset = 0 |
     var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
 
     if (withJamulus, {
-        var jackTripSignal = JackTripInput(maxClients - 1, inputChannelsPerClient, true, inputChannelsPerClient + offset).getSignal();
-        var jamulusSignal = JackTripInput(1, inputChannelsPerClient, true, offset).getSignal();
+        var jackTripSignal = JackTripInput(maxClients - 1, inputChannelsPerClient, useSoundIn, inputChannelsPerClient + offset).getSignal();
+        var jamulusSignal = JackTripInput(1, inputChannelsPerClient, useSoundIn, offset).getSignal();
         ~aggregateAndSendToAll.value(jackTripSignal, levels, maxClients, outputChannelsPerClient);
         ~sendFirstToEveryoneElse.value(jamulusSignal, levels, maxClients, outputChannelsPerClient);
     }, {
-        var jackTripSignal = JackTripInput(maxClients, inputChannelsPerClient, true, offset).getSignal();
+        var jackTripSignal = JackTripInput(maxClients, inputChannelsPerClient, useSoundIn, offset).getSignal();
         ~aggregateAndSendToAll.value(jackTripSignal, levels, maxClients, outputChannelsPerClient);
     });
 };

--- a/functions/jackTripSimpleMix.scd
+++ b/functions/jackTripSimpleMix.scd
@@ -14,19 +14,31 @@
  * limitations under the License.
  */
  
-"../functions/jackTripSimpleMix.scd".loadRelative;
+"aggregateAndSendToAll.scd".loadRelative;
+"sendFirstToEveryoneElse.scd".loadRelative;
 
  /*
- * JackTripSimpleMix: a minimal mix that scales well
+ * jackTripSimpleMix: a minimal mix that scales well
  *
  * \maxClients: maximum number of clients that may connect to the audio server
  * \inputChannelsPerClient: number of input channels received from each client
  * \outputChannelsPerClient: number of output channels sent to each client
  * \withJamulus: create mixes adapted Jamulus being connected on channels 1 & 2
+ * \offset: input channel offset used for reading audio input
  * \mix : array of amplitude level multipliers (default 1.0) for each client
  * \mul : master amplitude level multiplier (default 1.0)
  */
 
-~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    ~jackTripSimpleMix.value(maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus, 0);
+~jackTripSimpleMix = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false, offset = 0 |
+    var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
+
+    if (withJamulus, {
+        var jackTripSignal = JackTripInput(maxClients - 1, inputChannelsPerClient, true, inputChannelsPerClient + offset).getSignal();
+        var jamulusSignal = JackTripInput(1, inputChannelsPerClient, true, offset).getSignal();
+        ~aggregateAndSendToAll.value(jackTripSignal, levels, maxClients, outputChannelsPerClient);
+        ~sendFirstToEveryoneElse.value(jamulusSignal, levels, maxClients, outputChannelsPerClient);
+    }, {
+        var jackTripSignal = JackTripInput(maxClients, inputChannelsPerClient, true, offset).getSignal();
+        ~aggregateAndSendToAll.value(jackTripSignal, levels, maxClients, outputChannelsPerClient);
+    });
 };

--- a/mixers/AutoPanMix/AutoPanMix.sc
+++ b/mixers/AutoPanMix/AutoPanMix.sc
@@ -120,9 +120,9 @@ AutoPanMix : BaseMix {
 					this.sendSynthDef("JackTripSimpleIn");
 				});
 				if (maxClients > 100, {
-					this.sendSynthDef("JackTripSimpleMixFromBus", [~firstPrivateBus]);
+					this.sendSynthDef("JackTripSimpleMixFromBus");
 				}, {
-					this.sendSynthDef("JackTripPersonalMixOut", [~firstPrivateBus]);
+					this.sendSynthDef("JackTripPersonalMixOut");
 				});
 				
 				// use group 100 for client input synths and use group 200 for client output synths

--- a/mixers/AutoPanMix/AutoPanMix.sc
+++ b/mixers/AutoPanMix/AutoPanMix.sc
@@ -39,31 +39,28 @@
  * UGen's 0-index starts at the first hardware output bus. The Out UGen's 
  * 0-index starts at the first hardware output bus as well.
  *
- * Internally, a "jacktrip_panned_in" Synth is created, which
- * reads stereo audio from the hardware input buses to the corresponding private
- * buses, which are also stereo (see the instance variable inputBuses, which is an array
+ * Internally, a "JacktripPannedIn" Synth is created, which reads stereo audio from
+ * the hardware input buses to the corresponding private buses, which are also stereo
+ * (see the global variable ~inputBuses created by ~makeInputBusses, which is an array
  * of Bus objects that automatically allocates the correct number of private channels).
- * The variable inputBuses is used to route audio signals from the hardware input channels
+ * The variable ~inputBuses is used to route audio signals from the hardware input channels
  * to the private channels for each client. This is also where the panning process takes
  * place, using the LinLin UGen.
  *
- * If there are fewer than 100 clients, a "jacktrip_personalmix_out" Synth. Each client's
+ * If there are fewer than 100 clients, a "JackTripPersonalMixOut" Synth. Each client's
  * mix (which accounts for things like self-volume) is used to generate their unique
  * output audio. The mix for each client can also be thought of 
  * as an array of weights for the channels each client should hear. The
- * "jacktrip_personalmix_out" Synth computes the weighted sum of all of the clients'
+ * "JackTripPersonalMixOut" Synth computes the weighted sum of all of the clients'
  * audio signals and the resulting 2-channel signal to that particular client's
  * hardware output channel.
  *
- * If there are 100 clients or more, then no personal mixes are created. Rather, an
- * instance of "jamulus_simple_out" and only a single Synth instance of
- * "jacktrip_simple_out" is created for the server. These two synths essentially do the
- * same thing, but the "jamulus_simple_out" Synth excludes its own input (as an edge
- * case that is handled separately for channel 0). "jamulus_simple_out" creates one mix
- * that is sent to Jamulus on channel 0, and "jacktrip_simple_out" creates one mix that
- * is sent to all other clients. This only happens when there are greater than 100 clients
- * for performance reasons, though if there are fewer than 100 clients, personal mixes are
- * generated.
+ * If there are 100 clients or more, then no personal mixes are created. Rather, a
+ * single instance of "JackTripSimpleMix" is created for the server. This creates one
+ * mix that sends JackTrip audio to all clients, and another mix that sends Jamulus
+ * audio to all JackTrip clients (excluding itself). This only happens when there are
+ * greater than 100 clients for performance reasons, though if there are fewer than 100
+ * clients, personal mixes are generated.
  *
  * Note that SynthDefs are defined in the sendSynthDefs function, but are only
  * executed when the start function gets called. This may result in confusion, 
@@ -87,9 +84,6 @@ AutoPanMix : BaseMix {
 	// * lpf sets the default low-pass filter frequency used for all clients
 	// the '<' is shorthand for a getter method and '>' is shorthand for a setter method
 	var <>autopan, <>panSlots, <>selfVolume, <>hpf, <>lpf;
-
-	// inputBuses is an array (one per client) of stereo audio busses, after applying any processing
-	var inputBuses;
 
 	// create a new instance
 	*new { | maxClients = 16, autopan = true, panSlots = 3, selfVolume = 1.0, hpf = 20, lpf = 20000 |
@@ -120,8 +114,16 @@ AutoPanMix : BaseMix {
 				~makeInputBusses.value(server, maxClients, inputChannelsPerClient, outputChannelsPerClient);
 
 				// send synthDefs
-				this.sendSynthDefs(["JackTripPannedIn", "JackTripPersonalMixOut", "JackTripSimpleIn"]);
-				if (maxClients > 100, { this.sendSynthDef("JackTripSimpleMix"); });
+				if (autopan, {
+					this.sendSynthDef("JackTripPannedIn");
+				}, {
+					this.sendSynthDef("JackTripSimpleIn");
+				});
+				if (maxClients > 100, {
+					this.sendSynthDef("JackTripSimpleMixFromBus", [~firstPrivateBus]);
+				}, {
+					this.sendSynthDef("JackTripPersonalMixOut", [~firstPrivateBus]);
+				});
 				
 				// use group 100 for client input synths and use group 200 for client output synths
 				// p_new is a server command (see Server Command Reference on SC documentation)
@@ -153,8 +155,8 @@ AutoPanMix : BaseMix {
 			// and supernova throws mysterous bad_alloc errors
 			if (maxClients > 100, {
 				var node;
-				node = Synth("JackTripSimpleMix", [\mix, defaultMix, \mul, masterVolume], g, \addToTail);
-				("Created synth JackTripSimpleMix" + node.nodeID).postln;
+				node = Synth("JackTripSimpleMixFromBus", [\mix, defaultMix, \mul, masterVolume], g, \addToTail);
+				("Created synth JackTripSimpleMixFromBus" + node.nodeID).postln;
 			}, {
 
 				var node;

--- a/synthdefs/JackTripSimpleMix.scd
+++ b/synthdefs/JackTripSimpleMix.scd
@@ -28,5 +28,5 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    ~jackTripSimpleMix.value(maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus, 0);
+    ~jackTripSimpleMix.value(maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus, true, 0);
 };

--- a/synthdefs/JackTripSimpleMixFromBus.scd
+++ b/synthdefs/JackTripSimpleMixFromBus.scd
@@ -17,7 +17,7 @@
 "../functions/jackTripSimpleMix.scd".loadRelative;
 
  /*
- * JackTripSimpleMix: a minimal mix that scales well
+ * JackTripSimpleMixFromBus: a minimal mix that scales well and reads from input busses
  *
  * \maxClients: maximum number of clients that may connect to the audio server
  * \inputChannelsPerClient: number of input channels received from each client
@@ -28,5 +28,5 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    ~jackTripSimpleMix.value(maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus, 0);
+    ~jackTripSimpleMix.value(maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus, ~firstPrivateBus);
 };

--- a/synthdefs/JackTripSimpleMixFromBus.scd
+++ b/synthdefs/JackTripSimpleMixFromBus.scd
@@ -28,5 +28,5 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    ~jackTripSimpleMix.value(maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus, ~firstPrivateBus);
+    ~jackTripSimpleMix.value(maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);
 };


### PR DESCRIPTION
across SimpleMix and AutoPanMix. This needs to be a different
synthdef because otherwise the cache will cause troubles: switching
from one mixer to another will result in unpredictable behaviour.