### PR TITLE
Feature/add basic compander

### DIFF
--- a/functions/aggregateAndSendToAll.scd
+++ b/functions/aggregateAndSendToAll.scd
@@ -30,6 +30,7 @@
 	// adjust levels and aggregate JackTrip signal
 	var signal = MultiplyLink(levels).transform(in);
 	signal = AggregateLink().transform(signal);
+	signal = LimiterLink().transform(signal);
 
 	// send JackTrip signals to all outputs (including Jamulus)
 	out = Array.fill(maxClients, { arg n;

--- a/functions/sendFirstToEveryoneElse.scd
+++ b/functions/sendFirstToEveryoneElse.scd
@@ -29,7 +29,8 @@
 
 	// adjust levels
 	var signal = MultiplyLink(levels).transform(in);
-
+	signal = LimiterLink().transform(signal);
+	
 	// send Jamulus signal to JackTrip outputs
 	out = Array.fill(maxClients - 1, { arg n;
 		(n + 1) * outputChannelsPerClient;

--- a/links/CompressorLink.sc
+++ b/links/CompressorLink.sc
@@ -15,19 +15,21 @@
  */
 
 /* 
- * LimiterLink: prevents audio output from exceeding a specified volume threshold.
+ * CompressorLink: applies downward compression to an audio signal if the
+ * specified ratio is between 0 and 1.
  */
 
-LimiterLink : Link {
+CompressorLink : Link {
     var<> threshDB;
+    var<> ratio;
 
-	*new { | threshDB = -2 |
-		^super.new().threshDB_(threshDB);
+	*new { | threshDB = 0, ratio = 1 |
+		^super.new().threshDB_(threshDB).ratio_(ratio);
 	}
 
     transform { |input|
         var signal = input;
-        signal = Compander.ar(signal, signal, threshDB.dbamp, 1, 0.1);
+        signal = Compander.ar(signal, signal, threshDB.dbamp, 1, ratio);
         ^signal
     }
 }

--- a/links/GateLink.sc
+++ b/links/GateLink.sc
@@ -15,19 +15,21 @@
  */
 
 /* 
- * LimiterLink: prevents audio output from exceeding a specified volume threshold.
+ * GateLink: if the specified ratio is greater than 1, creates a noise gate such
+ * that no signal is passed through if a minimum volume threshold is not met.
  */
 
-LimiterLink : Link {
+GateLink : Link {
     var<> threshDB;
+    var<> ratio;
 
-	*new { | threshDB = -2 |
-		^super.new().threshDB_(threshDB);
+	*new { | threshDB = 0, ratio = 1 |
+		^super.new().threshDB_(threshDB).ratio_(ratio);
 	}
 
     transform { |input|
         var signal = input;
-        signal = Compander.ar(signal, signal, threshDB.dbamp, 1, 0.1);
+        signal = Compander.ar(signal, signal, threshDB.dbamp, ratio, 1);
         ^signal
     }
 }

--- a/links/LimiterLink.sc
+++ b/links/LimiterLink.sc
@@ -1,0 +1,34 @@
+/* 
+ * Copyright 2021 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* 
+ * LimiterLink: applies a low-pass
+ * and high-pass filter to a signal.
+ */
+
+LimiterLink : Link {
+    var<> dB;
+
+	*new { | limit = -3 |
+		^super.new().dB_(limit);
+	}
+
+    transform { |input|
+        var signal = input;
+        signal = Compander.ar(signal, signal, dB.dbamp, 1, 0.1);
+        ^signal
+    }
+}

--- a/links/LimiterLink.sc
+++ b/links/LimiterLink.sc
@@ -22,7 +22,7 @@
 LimiterLink : Link {
     var<> dB;
 
-	*new { | limit = -3 |
+	*new { | limit = -2 |
 		^super.new().dB_(limit);
 	}
 

--- a/synthdefs/JackTripPersonalMixOut.scd
+++ b/synthdefs/JackTripPersonalMixOut.scd
@@ -31,6 +31,7 @@
     
         var s = MultiplyLink(m * \mul.kr(1)).transform(signal);
         s = AggregateLink().transform(s);
+        s = LimiterLink().transform(s);
     
         Out.ar(outputChannelsPerClient * clientNum, s);
     });


### PR DESCRIPTION
Adds basic compression/expansion features.

- Adds a `LimiterLink` to all sound outputs, which by default is set at -2dB with a ratio of 0.1 above the threshold.
- Adds a `CompressorLink` and `GateLink` but does not yet integrate them into `AutoPanMix`.