### PR TITLE
Extract base gui dominick

### DIFF
--- a/functions/jackTripSimpleMix.scd
+++ b/functions/jackTripSimpleMix.scd
@@ -35,6 +35,7 @@
 
 	// adjust levels
 	signal = MultiplyLink(levels).transform(signal);
+    signal = SquashToMonoLink(true, false).transform(signal);
     signal = PanningLink(pan).transform(signal);
 
     if (withJamulus, {

--- a/functions/jackTripSimpleMix.scd
+++ b/functions/jackTripSimpleMix.scd
@@ -26,15 +26,16 @@
  * \withJamulus: create mixes adapted Jamulus being connected on channels 1 & 2
  * \useSoundIn: if true, use SoundIn() for input channels; otherwise, use In()
  * \offset: input channel offset used for reading audio input
- * \mix : array of amplitude level multipliers (default 1.0) for each client
- * \mul : master amplitude level multiplier (default 1.0)
+ * \levels : array of amplitude level multipliers for each client
+ * \pan : array of pans for each client
  */
 
-~jackTripSimpleMix = { | maxClients, levels, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false, useSoundIn = true, offset = 0 |
+~jackTripSimpleMix = { | maxClients, levels, pan, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false, useSoundIn = true, offset = 0 |
     var signal = JackTripInput(maxClients, inputChannelsPerClient, useSoundIn, offset).getSignal();
 
 	// adjust levels
 	signal = MultiplyLink(levels).transform(signal);
+    signal = PanningLink(pan).transform(signal);
 
     if (withJamulus, {
         ~aggregateAndSendToAll.value(signal, maxClients, outputChannelsPerClient, 1);

--- a/functions/jackTripSimpleMix.scd
+++ b/functions/jackTripSimpleMix.scd
@@ -30,9 +30,8 @@
  * \mul : master amplitude level multiplier (default 1.0)
  */
 
-~jackTripSimpleMix = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false, useSoundIn = true, offset = 0 |
+~jackTripSimpleMix = { | maxClients, levels, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false, useSoundIn = true, offset = 0 |
     var signal = JackTripInput(maxClients, inputChannelsPerClient, useSoundIn, offset).getSignal();
-    var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
 
 	// adjust levels
 	signal = MultiplyLink(levels).transform(signal);

--- a/synthdefs/JackTripPannedIn.scd
+++ b/synthdefs/JackTripPannedIn.scd
@@ -27,8 +27,8 @@
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
     var signal;
-    var defaultPan = [0 ! maxClients];
-    var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
+    var defaultPan = 0 ! maxClients;
+    var levels = \mix.kr(1 ! maxClients) * \mul.kr(1.0);
 
     signal = JackTripInput(maxClients, inputChannelsPerClient).getSignal();
     signal = BandPassFilterLink(\low.kr(20), \high.kr(20000)).transform(signal);

--- a/synthdefs/JackTripPannedIn.scd
+++ b/synthdefs/JackTripPannedIn.scd
@@ -27,7 +27,7 @@
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
     var signal;
-    var defaultPan = 0 ! maxClients;
+    var defaultPan = [0 ! maxClients];
     var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
 
     signal = JackTripInput(maxClients, inputChannelsPerClient).getSignal();

--- a/synthdefs/JackTripPannedIn.scd
+++ b/synthdefs/JackTripPannedIn.scd
@@ -27,8 +27,8 @@
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
     var signal;
-    var defaultPan = 0 ! maxClients;
-    var levels = \mix.kr(1 ! maxClients) * \mul.kr(1.0);
+    var defaultPan = [0 ! maxClients];
+    var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
 
     signal = JackTripInput(maxClients, inputChannelsPerClient).getSignal();
     signal = BandPassFilterLink(\low.kr(20), \high.kr(20000)).transform(signal);

--- a/synthdefs/JackTripSimpleMix.scd
+++ b/synthdefs/JackTripSimpleMix.scd
@@ -29,5 +29,6 @@
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
     var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
-    ~jackTripSimpleMix.value(maxClients, levels, inputChannelsPerClient, outputChannelsPerClient, withJamulus, true, 0);
+    var pan = \pan.kr([0 ! maxClients]);
+    ~jackTripSimpleMix.value(maxClients, levels, pan, inputChannelsPerClient, outputChannelsPerClient, withJamulus, true, 0);
 };

--- a/synthdefs/JackTripSimpleMix.scd
+++ b/synthdefs/JackTripSimpleMix.scd
@@ -28,5 +28,6 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    ~jackTripSimpleMix.value(maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus, true, 0);
+    var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
+    ~jackTripSimpleMix.value(maxClients, levels, inputChannelsPerClient, outputChannelsPerClient, withJamulus, true, 0);
 };

--- a/synthdefs/JackTripSimpleMix.scd
+++ b/synthdefs/JackTripSimpleMix.scd
@@ -29,6 +29,6 @@
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
     var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
-    var pan = \pan.kr([0 ! maxClients]);
+    var pan = \pan.kr(0 ! maxClients);
     ~jackTripSimpleMix.value(maxClients, levels, pan, inputChannelsPerClient, outputChannelsPerClient, withJamulus, true, 0);
 };

--- a/synthdefs/JackTripSimpleMix.scd
+++ b/synthdefs/JackTripSimpleMix.scd
@@ -28,8 +28,8 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    var defaultMix = [1 ! maxClients];
-    var defaultPan = [0 ! maxClients];
+    var defaultMix = 1 ! maxClients;
+    var defaultPan = 0 ! maxClients;
     var levels = \mix.kr(defaultMix) * \mul.kr(1.0);
     var pan = \pan.kr(defaultPan);
     ~jackTripSimpleMix.value(maxClients, levels, pan, inputChannelsPerClient, outputChannelsPerClient, withJamulus, true, 0);

--- a/synthdefs/JackTripSimpleMix.scd
+++ b/synthdefs/JackTripSimpleMix.scd
@@ -28,8 +28,8 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    var defaultMix = 1 ! maxClients;
-    var defaultPan = 0 ! maxClients;
+    var defaultMix = [1 ! maxClients];
+    var defaultPan = [0 ! maxClients];
     var levels = \mix.kr(defaultMix) * \mul.kr(1.0);
     var pan = \pan.kr(defaultPan);
     ~jackTripSimpleMix.value(maxClients, levels, pan, inputChannelsPerClient, outputChannelsPerClient, withJamulus, true, 0);

--- a/synthdefs/JackTripSimpleMix.scd
+++ b/synthdefs/JackTripSimpleMix.scd
@@ -28,7 +28,9 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
-    var pan = \pan.kr(0 ! maxClients);
+    var defaultMix = 1 ! maxClients;
+    var defaultPan = 0 ! maxClients;
+    var levels = \mix.kr(defaultMix) * \mul.kr(1.0);
+    var pan = \pan.kr(defaultPan);
     ~jackTripSimpleMix.value(maxClients, levels, pan, inputChannelsPerClient, outputChannelsPerClient, withJamulus, true, 0);
 };

--- a/synthdefs/JackTripSimpleMixFromBus.scd
+++ b/synthdefs/JackTripSimpleMixFromBus.scd
@@ -29,5 +29,5 @@
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
     var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
-    ~jackTripSimpleMix.value(maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);
+    ~jackTripSimpleMix.value(maxClients, levels, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);
 };

--- a/synthdefs/JackTripSimpleMixFromBus.scd
+++ b/synthdefs/JackTripSimpleMixFromBus.scd
@@ -28,8 +28,8 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    var defaultMix = 1 ! maxClients;
-    var defaultPan = 0 ! maxClients;
+    var defaultMix = [1 ! maxClients];
+    var defaultPan = [0 ! maxClients];
     var levels = \mix.kr(defaultMix) * \mul.kr(1.0);
     var pan = \pan.kr(defaultPan);
     ~jackTripSimpleMix.value(maxClients, levels, pan, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);

--- a/synthdefs/JackTripSimpleMixFromBus.scd
+++ b/synthdefs/JackTripSimpleMixFromBus.scd
@@ -28,5 +28,6 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
+    var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
     ~jackTripSimpleMix.value(maxClients, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);
 };

--- a/synthdefs/JackTripSimpleMixFromBus.scd
+++ b/synthdefs/JackTripSimpleMixFromBus.scd
@@ -28,8 +28,8 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    var defaultMix = [1 ! maxClients];
-    var defaultPan = [0 ! maxClients];
+    var defaultMix = 1 ! maxClients;
+    var defaultPan = 0 ! maxClients;
     var levels = \mix.kr(defaultMix) * \mul.kr(1.0);
     var pan = \pan.kr(defaultPan);
     ~jackTripSimpleMix.value(maxClients, levels, pan, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);

--- a/synthdefs/JackTripSimpleMixFromBus.scd
+++ b/synthdefs/JackTripSimpleMixFromBus.scd
@@ -28,7 +28,9 @@
  */
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
-    var pan = \pan.kr(0 ! maxClients);
+    var defaultMix = 1 ! maxClients;
+    var defaultPan = 0 ! maxClients;
+    var levels = \mix.kr(defaultMix) * \mul.kr(1.0);
+    var pan = \pan.kr(defaultPan);
     ~jackTripSimpleMix.value(maxClients, levels, pan, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);
 };

--- a/synthdefs/JackTripSimpleMixFromBus.scd
+++ b/synthdefs/JackTripSimpleMixFromBus.scd
@@ -29,6 +29,6 @@
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
     var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
-    var pan = \pan.kr([0 ! maxClients]);
+    var pan = \pan.kr(0 ! maxClients);
     ~jackTripSimpleMix.value(maxClients, levels, pan, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);
 };

--- a/synthdefs/JackTripSimpleMixFromBus.scd
+++ b/synthdefs/JackTripSimpleMixFromBus.scd
@@ -29,5 +29,6 @@
 
 ~synthDef = { | maxClients, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
     var levels = \mix.kr([1 ! maxClients]) * \mul.kr(1.0);
-    ~jackTripSimpleMix.value(maxClients, levels, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);
+    var pan = \pan.kr([0 ! maxClients]);
+    ~jackTripSimpleMix.value(maxClients, levels, pan, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);
 };


### PR DESCRIPTION
Improved refactored mixer. With these changes, the SuperCollider GUI - both the panning features and the volume levels mixing, will work on `AutoPanMix` and `SimpleMix`. Stylistic coding conventions are more well-defined, since all Control instances now live in the `/synthdefs`  directory.

Improvements to #21 .
