### PR TITLE
Fixed typo bug

### DIFF
--- a/functions/sendFirstToEveryoneElse.scd
+++ b/functions/sendFirstToEveryoneElse.scd
@@ -29,6 +29,6 @@
 		(n + 1) * outputChannelsPerClient;
 	});
 	var signal = signal[0];
-	var signal = LimitedLink().transform(signal);
+	var signal = LimiterLink().transform(signal);
 	Out.ar(out, signal);
 };


### PR DESCRIPTION
Fixed typo: `LimitedLink()` should be `LimiterLink()`