### PR TITLE
Work-around supercollider 3.12 regression

### DIFF
--- a/mixers/BaseMix.sc
+++ b/mixers/BaseMix.sc
@@ -66,7 +66,8 @@ BaseMix : Object {
 		// Create a new server object using the IP address and Port
 		// server can be used as one might use the 's' global variable locally
 		("Connecting to server"+serverIp++":"++serverPort).postln;
-		server = Server.remote(\remote, NetAddr(serverIp, serverPort));
+		// explicitly include empty ServerOptions to work-around 3.12 bug #5568
+		server = Server.remote(\remote, NetAddr(serverIp, serverPort), ServerOptions.new);
 		server.doWhenBooted({waitForServer.value});
 	}
 


### PR DESCRIPTION
SuperCollider 3.12 introduced a regression bug that breaks remote connections when a ServerOptions is not explicitly passed. For more info see https://github.com/supercollider/supercollider/issues/5568