### PR TITLE
Feature/make presets consistent

### DIFF
--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -31,15 +31,15 @@
           "options": [
               {
                   "name": "thresh",
-                  "value": -65
+                  "value": -60
               },
               {
                   "name": "attack",
-                  "value": 0.3
+                  "value": 0.01
               },
               {
                   "name": "release",
-                  "value": 0.01
+                  "value": 0.3
               },
               {
                   "name": "range",

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -110,7 +110,7 @@
           "options": [
               {
                   "name": "thresh",
-                  "value": -5
+                  "value": -10
               },
               {
                   "name": "attack",

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -31,15 +31,15 @@
           "options": [
               {
                   "name": "thresh",
-                  "value": -65
+                  "value": -60
               },
               {
                   "name": "attack",
-                  "value": 0.3
+                  "value": 0.01
               },
               {
                   "name": "release",
-                  "value": 0.01
+                  "value": 0.3
               },
               {
                   "name": "range",

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -26,6 +26,27 @@
     ]
   },
   "preChain": [
+    {
+        "name": "GateLink",
+        "options": [
+              {
+                  "name": "thresh",
+                  "value": -60
+              },
+              {
+                  "name": "attack",
+                  "value": 0.01
+              },
+              {
+                  "name": "release",
+                  "value": 0.3
+              },
+              {
+                  "name": "range",
+                  "value": 10
+              }
+          ]
+      },
       {
           "name": "PanningLink",
           "options": [

--- a/presets/RawStereoPreset/config.json
+++ b/presets/RawStereoPreset/config.json
@@ -25,7 +25,29 @@
         }
     ]
   },
-  "preChain": [],
+  "preChain": [
+    {
+        "name": "GateLink",
+        "options": [
+              {
+                  "name": "thresh",
+                  "value": -60
+              },
+              {
+                  "name": "attack",
+                  "value": 0.01
+              },
+              {
+                  "name": "release",
+                  "value": 0.3
+              },
+              {
+                  "name": "range",
+                  "value": 10
+              }
+          ]
+      }
+  ],
   "postChain": [
       {
           "name": "LimiterLink",

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -35,11 +35,11 @@
               },
               {
                   "name": "attack",
-                  "value": 0.3
+                  "value": 0.01
               },
               {
                   "name": "release",
-                  "value": 0.01
+                  "value": 0.3
               },
               {
                   "name": "range",


### PR DESCRIPTION
Unifies GateLink and LimiterLink for presets. For all presets we have:

On the input chain:
```
      {
          "name": "GateLink",
          "options": [
              {
                  "name": "thresh",
                  "value": -60
              },
              {
                  "name": "attack",
                  "value": 0.01
              },
              {
                  "name": "release",
                  "value": 0.3
              },
              {
                  "name": "range",
                  "value": 10
              }
          ]
      }
```

On the output chain:
```
      {
          "name": "LimiterLink",
          "options": [
              {
                  "name": "thresh",
                  "value": -10
              },
              {
                  "name": "attack",
                  "value": 0.002
              },
              {
                  "name": "release",
                  "value": 0.01
              },
              {
                  "name": "ratio",
                  "value": 0.033
              }
          ]
      }
```