### PR TITLE
Feature/specify chains for links

### DIFF
--- a/links/CirclePanLink/config.json
+++ b/links/CirclePanLink/config.json
@@ -1,6 +1,7 @@
 {
     "label": "Circular Pan",
     "class": "CirclePanLink",
+    "disallowPostChain": true,
     "options": [
         {
             "src": "panSlots",

--- a/links/ConvReverbLink/config.json
+++ b/links/ConvReverbLink/config.json
@@ -1,6 +1,7 @@
 {
     "label": "Convolution Reverb",
     "class": "ConvReverbLink",
+    "disallowPreChain": true,
     "options": [
         {
             "src": "irPath",

--- a/links/DragonflyEarlyReflectionsReverbLink/config.json
+++ b/links/DragonflyEarlyReflectionsReverbLink/config.json
@@ -1,6 +1,7 @@
 {
     "label": "Dragonfly Early Reflections Reverb",
     "class": "DragonflyEarlyReflectionsReverbLink",
+    "disallowPreChain": true,
     "options": [
         {
             "src": "dry",

--- a/links/DragonflyHallReverbLink/config.json
+++ b/links/DragonflyHallReverbLink/config.json
@@ -1,6 +1,7 @@
 {
     "label": "Dragonfly Hall Reverb",
     "class": "DragonflyHallReverbLink",
+    "disallowPreChain": true,
     "options": [
         {
             "src": "dry",

--- a/links/DragonflyPlateReverbLink/config.json
+++ b/links/DragonflyPlateReverbLink/config.json
@@ -1,6 +1,7 @@
 {
     "label": "Dragonfly Plate Reverb",
     "class": "DragonflyPlateReverbLink",
+    "disallowPreChain": true,
     "options": [
         {
             "src": "dry",

--- a/links/DragonflyRoomReverbLink/config.json
+++ b/links/DragonflyRoomReverbLink/config.json
@@ -1,6 +1,7 @@
 {
     "label": "Dragonfly Room Reverb",
     "class": "DragonflyRoomReverbLink",
+    "disallowPreChain": true,
     "options": [
         {
             "src": "dry",

--- a/links/FreeVerb2Link/config.json
+++ b/links/FreeVerb2Link/config.json
@@ -1,6 +1,7 @@
 {
     "label": "FreeVerb (stereo)",
     "class": "FreeVerb2Link",
+    "disallowPreChain": true,
     "options": [
         {
             "src": "mix",

--- a/links/FreeVerbLink/config.json
+++ b/links/FreeVerbLink/config.json
@@ -1,6 +1,7 @@
 {
     "label": "FreeVerb",
     "class": "FreeVerbLink",
+    "disallowPreChain": true,
     "options": [
         {
             "src": "mix",

--- a/links/GVerbLink/config.json
+++ b/links/GVerbLink/config.json
@@ -1,6 +1,7 @@
 {
     "label": "GVerb",
     "class": "GVerbLink",
+    "disallowPreChain": true,
     "options": [
         {
             "src": "room",

--- a/links/PanningLink/config.json
+++ b/links/PanningLink/config.json
@@ -1,6 +1,7 @@
 {
     "label": "Pan",
     "class": "PanningLink",
+    "disallowPostChain": true,
     "options": [
         {
             "src": "panSlots",

--- a/links/SpherePanLink/config.json
+++ b/links/SpherePanLink/config.json
@@ -1,6 +1,7 @@
 {
     "label": "Spherical Pan",
     "class": "SpherePanLink",
+    "disallowPostChain": true,
     "options": [
         {
             "src": "panSlots",

--- a/links/TalReverbLink/config.json
+++ b/links/TalReverbLink/config.json
@@ -2,6 +2,7 @@
     "label": "Tal Reverb 4",
     "class": "TalReverbLink",
     "enabled": false,
+    "disallowPreChain": true,
     "options": [
         {
             "src": "wet",

--- a/links/TalReverbLink/config.json
+++ b/links/TalReverbLink/config.json
@@ -1,7 +1,7 @@
 {
     "label": "Tal Reverb 4",
     "class": "TalReverbLink",
-    "enabled": false,
+    "disabled": true,
     "disallowPreChain": true,
     "options": [
         {

--- a/links/TalReverbLink/config.json
+++ b/links/TalReverbLink/config.json
@@ -1,7 +1,7 @@
 {
     "label": "Tal Reverb 4",
     "class": "TalReverbLink",
-    "disabled": true,
+    "disallowPostChain": true,
     "disallowPreChain": true,
     "options": [
         {


### PR DESCRIPTION
Selects which links can go on which chains. Panning links can only go on input chains, and reverb links can only go on output chains.

Additionally, we should use `disabled` rather than `enabled` as a field to determine whether to include a link at all, so that `linkData.disabled` returns `false` / `null`  if the field does not exist or is specified as false. If using `enabled`, then `linkData.enabled` returns false/null if the field does not exist which I think isn't the right behavior (we want enabled by default).