### PR TITLE
Created a new SelfVolumeMixer

### DIFF
--- a/functions/makeInputBuses.scd
+++ b/functions/makeInputBuses.scd
@@ -21,9 +21,10 @@
 // audio output channels
 // private buses are reserved for internally routing audio signals
 
-~makeInputBusses = { | server, maxClients, inputChannelsPerClient, outputChannelsPerClient |
+~makeInputBuses = { | server, maxClients, inputChannelsPerClient, outputChannelsPerClient |
     ~firstPrivateBus = (maxClients * (inputChannelsPerClient + outputChannelsPerClient));
-    ~inputBuses = Array.fill(maxClients, { |n|
+    ~masterInputBus = ~firstPrivateBus + (inputChannelsPerClient * maxClients);
+    ~inputBuses = Array.fill(maxClients + 1, { |n|
         var i = ~firstPrivateBus + (n * inputChannelsPerClient);
         Bus.new('audio', i, inputChannelsPerClient, server);
     });

--- a/mixers/BaseMixer.sc
+++ b/mixers/BaseMixer.sc
@@ -25,6 +25,7 @@ BaseMixer : Object {
     var <>withJamulus = true;		// create mixes adapted Jamulus being connected on channels 1 & 2
     var <>useSynthCache = true;		// send each synth definition to the server at most one time
     var <>masterVolume = 1.0;		// master volume level multiplier
+    var <>selfVolume = 1.0;         // sets the default volume level that each client will hear themselves at (requires personal mixes)
     var <>serverIp = "127.0.0.1";	// IP address or hostname of remote audio server
     var <>serverPort = 57110;		// port number of remote audio server (default SC port)
     var <>serverReady, <>server;    // state of the server and the server object

--- a/mixers/InputBusMixer.sc
+++ b/mixers/InputBusMixer.sc
@@ -41,7 +41,7 @@
  *
  * Internally, a "JackTripToInputBus" Synth is created, which reads stereo audio from
  * the hardware input buses to the corresponding private buses, which are also stereo
- * (see the global variable ~inputBuses created by ~makeInputBusses, which is an array
+ * (see the global variable ~inputBuses created by ~makeInputBuses, which is an array
  * of Bus objects that automatically allocates the correct number of private channels).
  * The variable ~inputBuses is used to route audio signals from the hardware input channels
  * to the private channels for each client.
@@ -89,8 +89,8 @@ InputBusMixer : BaseMixer {
         // create a bundle of commands to execute
         b = server.makeBundle(nil, {
             // make input busses
-            (this.class.filenameSymbol.asString.dirname +/+ "../../functions/makeInputBusses.scd").load;
-            ~makeInputBusses.value(server, maxClients, inputChannelsPerClient, outputChannelsPerClient);
+            (this.class.filenameSymbol.asString.dirname +/+ "../../functions/makeInputBuses.scd").load;
+            ~makeInputBuses.value(server, maxClients, inputChannelsPerClient, outputChannelsPerClient);
 
             // initialize ATK decoder
             (this.class.filenameSymbol.asString.dirname +/+ "../../functions/initATK.scd").load;

--- a/mixers/OutputBusMixer/OutputBusMixer.sc
+++ b/mixers/OutputBusMixer/OutputBusMixer.sc
@@ -72,7 +72,7 @@ OutputBusMixer : InputBusMixer {
             }, {
                 args = [\mix, defaultMix, \mul, masterVolume] ++ postChain.getArgs();
                 node = Synth(synthName ++ postChainName, args, g, \addToTail);
-                // execute preChain after actions
+                // execute postChain after actions
                 postChain.after(server, node);
             });
             ("Created synth" + (synthName ++ postChainName) + node.nodeID).postln;

--- a/mixers/OutputBusMixer/config.json
+++ b/mixers/OutputBusMixer/config.json
@@ -1,7 +1,6 @@
 {
-    "label": "Large Ensemble (100-300 musicians)",
+    "label": "Efficient Mixer (with signal chains)",
     "class": "OutputBusMixer",
-    "max": 300,
     "options": [
         {
             "src": "masterVolume",

--- a/mixers/PersonalMixer/config.json
+++ b/mixers/PersonalMixer/config.json
@@ -1,7 +1,6 @@
 {
     "label": "Personal Mixer",
     "class": "PersonalMixer",
-    "max": 100,
     "options": [
         {
             "src": "masterVolume",

--- a/mixers/SelfVolumeMixer/SelfVolumeMixer.sc
+++ b/mixers/SelfVolumeMixer/SelfVolumeMixer.sc
@@ -106,11 +106,12 @@ SelfVolumeMixer : InputBusMixer {
                 }, {
                     args = args ++ postChain.getArgs();
                     node = Synth(synthName ++ postChainName, args, g, \addToTail);
-                    // execute postChain after actions
-                    postChain.after(server, node);
                 });
                 ("Created synth" + (synthName ++ postChainName) + node.nodeID).postln;
             };
+
+            // execute postChain after actions
+            postChain.after(server, node);
 
             // signal that the mix has started
             // signal is defined in the BaseMix class and represents a Condition object

--- a/mixers/SelfVolumeMixer/config.json
+++ b/mixers/SelfVolumeMixer/config.json
@@ -1,6 +1,6 @@
 {
-    "label": "Personal Mixer",
-    "class": "PersonalMixer",
+    "label": "Self Volume Mixer (Default)",
+    "class": "SelfVolumeMixer",
     "max": 100,
     "options": [
         {

--- a/mixers/SelfVolumeMixer/config.json
+++ b/mixers/SelfVolumeMixer/config.json
@@ -1,7 +1,6 @@
 {
     "label": "Self Volume Mixer (Default)",
     "class": "SelfVolumeMixer",
-    "max": 100,
     "options": [
         {
             "src": "masterVolume",

--- a/mixers/SimpleMixer/config.json
+++ b/mixers/SimpleMixer/config.json
@@ -1,7 +1,8 @@
 {
-    "label": "Extra Large Ensemble (>300 musicians)",
+    "label": "Simple Mixer (No signal chains)",
     "class": "SimpleMixer",
-    "max": 500,
+    "disallowPostChain": true,
+    "disallowPreChain": true,
     "options": [
         {
             "src": "masterVolume",

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -2,6 +2,16 @@
   "id": "default-mix",
   "label": "Standard",
   "mixerOptions": {
+    "SelfVolumeMixer": [
+        {
+            "name": "masterVolume",
+            "value": 1.5
+        },
+        {
+            "name": "selfVolume",
+            "value": 0.1
+        }
+    ],
     "PersonalMixer": [
         {
             "name": "masterVolume",

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -1,6 +1,11 @@
 {
   "id": "default-mix",
   "label": "Standard",
+  "mixerMax": [
+    { "SelfVolumeMixer": 20 },
+    { "OutputBusMixer": 64 },
+    { "SimpleMixer": 500 }
+  ],
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -3,8 +3,7 @@
   "label": "Standard",
   "mixerMax": [
     { "SelfVolumeMixer": 20 },
-    { "OutputBusMixer": 64 },
-    { "SimpleMixer": 500 }
+    { "OutputBusMixer": 80 }
   ],
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -22,7 +22,7 @@
             "value": 0.1
         }
     ],
-    "OuputBusMixer": [
+    "OutputBusMixer": [
         {
             "name": "masterVolume",
             "value": 1.5

--- a/presets/DryRoomPreset/config.json
+++ b/presets/DryRoomPreset/config.json
@@ -1,48 +1,48 @@
 {
-  "id": "raw-stereo",
-  "label": "Raw Stereo",
+  "id": "dry-room",
+  "label": "Dry Room",
   "mixerMax": [
-    { "SelfVolumeMixer": 180 },
+    { "SelfVolumeMixer": 120 },
     { "OutputBusMixer": 180 }
   ],
   "mixerOptions": {
     "SelfVolumeMixer": [
         {
             "name": "masterVolume",
-            "value": 1
+            "value": 1.5
         },
         {
             "name": "selfVolume",
-            "value": 0
+            "value": 0.1
         }
     ],
     "PersonalMixer": [
         {
             "name": "masterVolume",
-            "value": 1
+            "value": 1.5
         },
         {
             "name": "selfVolume",
-            "value": 0
+            "value": 0.1
         }
     ],
     "OutputBusMixer": [
         {
             "name": "masterVolume",
-            "value": 1
+            "value": 1.5
         }
     ],
     "SimpleMixer": [
         {
             "name": "masterVolume",
-            "value": 1
+            "value": 1.5
         }
     ]
   },
   "preChain": [
-    {
-        "name": "GateLink",
-        "options": [
+      {
+          "name": "GateLink",
+          "options": [
               {
                   "name": "thresh",
                   "value": -60
@@ -60,27 +60,28 @@
                   "value": 10
               }
           ]
-      }
-  ],
-  "postChain": [
+      },
       {
-          "name": "LimiterLink",
+          "name": "BandPassFilterLink",
           "options": [
               {
-                  "name": "thresh",
-                  "value": -10
-              },
+                  "names": [
+                      "low",
+                      "high"
+                  ],
+                  "values": [
+                      100.66998409579647,
+                      20000.000000000004
+                  ]
+              }
+          ]
+      },
+      {
+          "name": "PanningLink",
+          "options": [
               {
-                  "name": "attack",
-                  "value": 0.002
-              },
-              {
-                  "name": "release",
-                  "value": 0.01
-              },
-              {
-                  "name": "ratio",
-                  "value": 0.033
+                  "name": "panSlots",
+                  "value": 1
               }
           ]
       }

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -3,8 +3,7 @@
   "label": "Echo Hall",
   "mixerMax": [
     { "SelfVolumeMixer": 20 },
-    { "OutputBusMixer": 64 },
-    { "SimpleMixer": 500 }
+    { "OutputBusMixer": 80 }
   ],
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -2,6 +2,16 @@
   "id": "echo-hall",
   "label": "Echo Hall",
   "mixerOptions": {
+    "SelfVolumeMixer": [
+        {
+            "name": "masterVolume",
+            "value": 1.5
+        },
+        {
+            "name": "selfVolume",
+            "value": 0.7
+        }
+    ],
     "PersonalMixer": [
         {
             "name": "masterVolume",

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -1,6 +1,11 @@
 {
   "id": "echo-hall",
   "label": "Echo Hall",
+  "mixerMax": [
+    { "SelfVolumeMixer": 20 },
+    { "OutputBusMixer": 64 },
+    { "SimpleMixer": 500 }
+  ],
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -22,7 +22,7 @@
             "value": 0.7
         }
     ],
-    "OuputBusMixer": [
+    "OutputBusMixer": [
         {
             "name": "masterVolume",
             "value": 1.5

--- a/presets/LargeGroupPreset/config.json
+++ b/presets/LargeGroupPreset/config.json
@@ -1,0 +1,33 @@
+{
+  "id": "large-group",
+  "label": "Large Group",
+  "mixerMax": [
+    { "SimpleMixer": 500 }
+  ],
+  "mixerOptions": {
+    "SelfVolumeMixer": [
+        {
+            "name": "masterVolume",
+            "value": 1.5
+        }
+    ],
+    "PersonalMixer": [
+        {
+            "name": "masterVolume",
+            "value": 1.5
+        }
+    ],
+    "OutputBusMixer": [
+        {
+            "name": "masterVolume",
+            "value": 1.5
+        }
+    ],
+    "SimpleMixer": [
+        {
+            "name": "masterVolume",
+            "value": 1.5
+        }
+    ]
+  }
+}

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -2,7 +2,7 @@
   "id": "mic-test",
   "label": "Microphone Test",
   "mixerMax": [
-    { "SelfVolumeMixer": 64 }
+    { "SelfVolumeMixer": 180 }
   ],
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -22,7 +22,7 @@
             "value": 3
         }
     ],
-    "OuputBusMixer": [
+    "OutputBusMixer": [
         {
             "name": "masterVolume",
             "value": 1

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -1,6 +1,9 @@
 {
   "id": "mic-test",
   "label": "Microphone Test",
+  "mixerMax": [
+    { "SelfVolumeMixer": 64 }
+  ],
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -2,6 +2,16 @@
   "id": "mic-test",
   "label": "Microphone Test",
   "mixerOptions": {
+    "SelfVolumeMixer": [
+        {
+            "name": "masterVolume",
+            "value": 0.5
+        },
+        {
+            "name": "selfVolume",
+            "value": 3
+        }
+    ],
     "PersonalMixer": [
         {
             "name": "masterVolume",

--- a/presets/RawStereoPreset/config.json
+++ b/presets/RawStereoPreset/config.json
@@ -2,6 +2,16 @@
   "id": "raw-stereo",
   "label": "Raw Stereo",
   "mixerOptions": {
+    "SelfVolumeMixer": [
+        {
+            "name": "masterVolume",
+            "value": 1
+        },
+        {
+            "name": "selfVolume",
+            "value": 0
+        }
+    ],
     "PersonalMixer": [
         {
             "name": "masterVolume",

--- a/presets/RawStereoPreset/config.json
+++ b/presets/RawStereoPreset/config.json
@@ -22,7 +22,7 @@
             "value": 0
         }
     ],
-    "OuputBusMixer": [
+    "OutputBusMixer": [
         {
             "name": "masterVolume",
             "value": 1

--- a/presets/RawStereoPreset/config.json
+++ b/presets/RawStereoPreset/config.json
@@ -1,6 +1,11 @@
 {
   "id": "raw-stereo",
   "label": "Raw Stereo",
+  "mixerMax": [
+    { "SelfVolumeMixer": 20 },
+    { "OutputBusMixer": 80 },
+    { "SimpleMixer": 500 }
+  ],
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -2,6 +2,16 @@
   "id": "rehearsal-room",
   "label": "Rehearsal Room",
   "mixerOptions": {
+    "SelfVolumeMixer": [
+        {
+            "name": "masterVolume",
+            "value": 1.5
+        },
+        {
+            "name": "selfVolume",
+            "value": 0.2
+        }
+    ],
     "PersonalMixer": [
         {
             "name": "masterVolume",

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -1,6 +1,11 @@
 {
   "id": "rehearsal-room",
   "label": "Rehearsal Room",
+  "mixerMax": [
+    { "SelfVolumeMixer": 20 },
+    { "OutputBusMixer": 64 },
+    { "SimpleMixer": 500 }
+  ],
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -3,8 +3,7 @@
   "label": "Rehearsal Room",
   "mixerMax": [
     { "SelfVolumeMixer": 20 },
-    { "OutputBusMixer": 64 },
-    { "SimpleMixer": 500 }
+    { "OutputBusMixer": 80 }
   ],
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -22,7 +22,7 @@
             "value": 0.2
         }
     ],
-    "OuputBusMixer": [
+    "OutputBusMixer": [
         {
             "name": "masterVolume",
             "value": 1.5

--- a/synthdefs/JackTripDownMixOut.scd
+++ b/synthdefs/JackTripDownMixOut.scd
@@ -28,7 +28,24 @@
  */
 
 ~synthDef = { | maxClients, preChain, postChain, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    var defaultMix = 1 ! maxClients;
-    var levels = \mix.kr(defaultMix) * \mul.kr(1.0);
-    ~jackTripSimpleMix.value(postChain, maxClients, levels, inputChannelsPerClient, outputChannelsPerClient, withJamulus, false, ~firstPrivateBus);
+    var masterSignal = JackTripInput(1, inputChannelsPerClient, false, ~masterInputBus).getSignal();
+    var masterOut = Array.fill(maxClients, { |n| n * outputChannelsPerClient; });
+    var masterVolume = \mul.kr(1.0);
+    var signal;
+
+    if (withJamulus, {
+        var jamulusSignal = JackTripInput(1, inputChannelsPerClient, false, ~firstPrivateBus).getSignal();
+        signal = masterSignal ++ jamulusSignal;
+        signal = MulAdd(signal, [masterVolume, -1.0], 0);
+        signal = AggregateLink().ar(signal);
+        signal = postChain.ar(signal);
+        Out.ar(0, signal);
+        masterOut.removeAt(0);
+    });
+
+    signal = masterSignal;
+    signal = MulAdd(signal, masterVolume, 0);
+    signal = AggregateLink().ar(signal);
+    signal = postChain.ar(signal);
+    Out.ar(masterOut, signal);
 };

--- a/synthdefs/JackTripSelfVolumeMixOut.scd
+++ b/synthdefs/JackTripSelfVolumeMixOut.scd
@@ -13,25 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/*
- * JackTripToInputBus is used to apply leveling, and a pre signal chain
- * to process audio from JackTrip and deliver it to the input audio bus
+ 
+ /*
+ * JackTripSelfVolumeMixOut: uses subtractive synthesis to implement self volume
  *
+ * \maxClients: maximum number of clients that may connect to the audio server
+ * \inputChannelsPerClient: number of input channels received from each client
+ * \outputChannelsPerClient: number of output channels sent to each client
+ * \withJamulus: create mixes adapted Jamulus being connected on channels 1 & 2
  * \mix : array of amplitude level multipliers (default 1.0) for each client
  * \mul : master amplitude level multiplier (default 1.0)
  */
 
 ~synthDef = { | maxClients, preChain, postChain, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    var signal;
-    var defaultMix = 1 ! maxClients;
-    var levels = \mix.kr(defaultMix) * \mul.kr(1.0);
-
-    signal = JackTripInput(maxClients, inputChannelsPerClient).getSignal();
-    signal = MulAdd(signal, levels, 0);
-    signal = preChain.ar(signal);
-
-    signal.do({ arg item, i;
-        Out.ar([~masterInputBus, ~inputBuses[i].index], item);
-    });
-}
+    var masterSignal = JackTripInput(1, inputChannelsPerClient, false, ~masterInputBus).getSignal();
+    var selfSignal = JackTripInput(1, inputChannelsPerClient, false, \in.ir(0)).getSignal();
+    var signal = masterSignal ++ selfSignal;
+    signal = MulAdd(signal, [\masterVolume.kr(1.0), \extraSelfVolume.kr(0)], 0);
+    signal = AggregateLink().ar(signal);
+    signal = postChain.ar(signal);
+    Out.ar(\out.ir(0), signal);
+};


### PR DESCRIPTION
Compared to PersonalMixer, this uses subtractive synthesis to generate personal mixes for "self volume" functionality. The primary advantage being that only two bus channels need to be mixed down when producing client output, versus N bus channels (where N = max number of clients). When using supernova (versus scsynth), this performs far (almost 4x) better than PersonalMixer, without loss of functionality (given that we currently are only leveraging self volume).

I also updated InputBusMixer so that it writes signs to two busses for each client versus one. I did a bunch of testing to convince myself that this doesn't introduce a performance regression for other mixers that use it (namely PersonalMixer and OutputBusMixer), but only with about 40 stereo clients. Its probably worth doing larger scale tests to further verify.

Fixed some misc typos and names as well.