### PR TITLE
Feature/mixer max as object

### DIFF
--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -1,10 +1,10 @@
 {
   "id": "default-mix",
   "label": "Standard",
-  "mixerMax": [
-    { "SelfVolumeMixer": 20 },
-    { "OutputBusMixer": 80 }
-  ],
+  "mixerMax": {
+      "SelfVolumeMixer": 20,
+      "OutputBusMixer": 80
+  },
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -2,8 +2,8 @@
   "id": "default-mix",
   "label": "Standard",
   "mixerMax": {
-      "SelfVolumeMixer": 20,
-      "OutputBusMixer": 80
+    "SelfVolumeMixer": 20,
+    "OutputBusMixer": 80
   },
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/DryRoomPreset/config.json
+++ b/presets/DryRoomPreset/config.json
@@ -2,8 +2,8 @@
   "id": "dry-room",
   "label": "Dry Room",
   "mixerMax": {
-      "SelfVolumeMixer": 120,
-      "OutputBusMixer": 180
+    "SelfVolumeMixer": 120,
+    "OutputBusMixer": 180
   },
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/DryRoomPreset/config.json
+++ b/presets/DryRoomPreset/config.json
@@ -1,10 +1,10 @@
 {
   "id": "dry-room",
   "label": "Dry Room",
-  "mixerMax": [
-    { "SelfVolumeMixer": 120 },
-    { "OutputBusMixer": 180 }
-  ],
+  "mixerMax": {
+      "SelfVolumeMixer": 120,
+      "OutputBusMixer": 180
+  },
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -2,8 +2,8 @@
   "id": "echo-hall",
   "label": "Echo Hall",
   "mixerMax": {
-      "SelfVolumeMixer": 20,
-      "OutputBusMixer": 80
+    "SelfVolumeMixer": 20,
+    "OutputBusMixer": 80
   },
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -1,10 +1,10 @@
 {
   "id": "echo-hall",
   "label": "Echo Hall",
-  "mixerMax": [
-    { "SelfVolumeMixer": 20 },
-    { "OutputBusMixer": 80 }
-  ],
+  "mixerMax": {
+      "SelfVolumeMixer": 20,
+      "OutputBusMixer": 80
+  },
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/LargeGroupPreset/config.json
+++ b/presets/LargeGroupPreset/config.json
@@ -2,7 +2,7 @@
   "id": "large-group",
   "label": "Large Group",
   "mixerMax": {
-      "SimpleMixer": 500
+    "SimpleMixer": 500
   },
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/LargeGroupPreset/config.json
+++ b/presets/LargeGroupPreset/config.json
@@ -1,9 +1,9 @@
 {
   "id": "large-group",
   "label": "Large Group",
-  "mixerMax": [
-    { "SimpleMixer": 500 }
-  ],
+  "mixerMax": {
+      "SimpleMixer": 500
+  },
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -2,7 +2,7 @@
   "id": "mic-test",
   "label": "Microphone Test",
   "mixerMax": {
-      "SelfVolumeMixer": 180
+    "SelfVolumeMixer": 180
   },
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -1,9 +1,9 @@
 {
   "id": "mic-test",
   "label": "Microphone Test",
-  "mixerMax": [
-    { "SelfVolumeMixer": 180 }
-  ],
+  "mixerMax": {
+      "SelfVolumeMixer": 180
+  },
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/RawStereoPreset/config.json
+++ b/presets/RawStereoPreset/config.json
@@ -1,10 +1,10 @@
 {
   "id": "raw-stereo",
   "label": "Raw Stereo",
-  "mixerMax": [
-    { "SelfVolumeMixer": 180 },
-    { "OutputBusMixer": 180 }
-  ],
+  "mixerMax": {
+      "SelfVolumeMixer": 180,
+      "OutputBusMixer": 180
+  },
   "mixerOptions": {
     "SelfVolumeMixer": [
         {

--- a/presets/RawStereoPreset/config.json
+++ b/presets/RawStereoPreset/config.json
@@ -2,8 +2,8 @@
   "id": "raw-stereo",
   "label": "Raw Stereo",
   "mixerMax": {
-      "SelfVolumeMixer": 180,
-      "OutputBusMixer": 180
+    "SelfVolumeMixer": 180,
+    "OutputBusMixer": 180
   },
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -2,8 +2,8 @@
   "id": "rehearsal-room",
   "label": "Rehearsal Room",
   "mixerMax": {
-      "SelfVolumeMixer": 20,
-      "OutputBusMixer": 80
+    "SelfVolumeMixer": 20,
+    "OutputBusMixer": 80
   },
   "mixerOptions": {
     "SelfVolumeMixer": [

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -1,10 +1,10 @@
 {
   "id": "rehearsal-room",
   "label": "Rehearsal Room",
-  "mixerMax": [
-    { "SelfVolumeMixer": 20 },
-    { "OutputBusMixer": 80 }
-  ],
+  "mixerMax": {
+      "SelfVolumeMixer": 20,
+      "OutputBusMixer": 80
+  },
   "mixerOptions": {
     "SelfVolumeMixer": [
         {


### PR DESCRIPTION
I think a better way to store the `mixerMax` data would be as an object, with the key as the mixer and the value as the server size. It's a little inconvenient to parse, since each item in the array has a different key. With the `mixerMax` item as an object, we can use `Object.keys()` to get the list of allowed mixers.

Alternatively, if we really wanted to use an array, we could do something like:

```
"mixers": [
    { 
        "mixer": "SelfVolumeMixer",
        "max": 20
    },
    { 
        "mixer": "OutputBusMixer",
        "max": 80
    }
]
```