### PR TITLE
Feature/reformat preset mixers

### DIFF
--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -1,28 +1,32 @@
 {
   "id": "default-mix",
   "label": "Standard",
-  "mixerMax": [
-    { "SelfVolumeMixer": 20 },
-    { "OutputBusMixer": 80 }
+  "mixers": [
+    {
+        "mixer": "SelfVolumeMixer",
+        "max": 20,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1.5
+            },
+            {
+                "name": "selfVolume",
+                "value": 0.1
+            }
+        ]
+    },
+    {
+        "mixer": "OutputBusMixer",
+        "max": 80,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1.5
+            }
+        ]
+    }
   ],
-  "mixerOptions": {
-    "SelfVolumeMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        },
-        {
-            "name": "selfVolume",
-            "value": 0.1
-        }
-    ],
-    "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ]
-  },
   "preChain": [
       {
           "name": "GateLink",

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -16,23 +16,7 @@
             "value": 0.1
         }
     ],
-    "PersonalMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        },
-        {
-            "name": "selfVolume",
-            "value": 0.1
-        }
-    ],
     "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ],
-    "SimpleMixer": [
         {
             "name": "masterVolume",
             "value": 1.5

--- a/presets/DryRoomPreset/config.json
+++ b/presets/DryRoomPreset/config.json
@@ -1,28 +1,32 @@
 {
   "id": "dry-room",
   "label": "Dry Room",
-  "mixerMax": [
-    { "SelfVolumeMixer": 120 },
-    { "OutputBusMixer": 180 }
+  "mixers": [
+    {
+        "mixer": "SelfVolumeMixer",
+        "max": 120,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1.5
+            },
+            {
+                "name": "selfVolume",
+                "value": 0.1
+            }
+        ]
+    },
+    {
+        "mixer": "OutputBusMixer",
+        "max": 180,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1.5
+            }
+        ]
+    }
   ],
-  "mixerOptions": {
-    "SelfVolumeMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        },
-        {
-            "name": "selfVolume",
-            "value": 0.1
-        }
-    ],
-    "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ]
-  },
   "preChain": [
       {
           "name": "GateLink",

--- a/presets/DryRoomPreset/config.json
+++ b/presets/DryRoomPreset/config.json
@@ -16,23 +16,7 @@
             "value": 0.1
         }
     ],
-    "PersonalMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        },
-        {
-            "name": "selfVolume",
-            "value": 0.1
-        }
-    ],
     "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ],
-    "SimpleMixer": [
         {
             "name": "masterVolume",
             "value": 1.5

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -16,23 +16,7 @@
             "value": 0.7
         }
     ],
-    "PersonalMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        },
-        {
-            "name": "selfVolume",
-            "value": 0.7
-        }
-    ],
     "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ],
-    "SimpleMixer": [
         {
             "name": "masterVolume",
             "value": 1.5

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -1,28 +1,32 @@
 {
   "id": "echo-hall",
   "label": "Echo Hall",
-  "mixerMax": [
-    { "SelfVolumeMixer": 20 },
-    { "OutputBusMixer": 80 }
+  "mixers": [
+    {
+        "mixer": "SelfVolumeMixer",
+        "max": 20,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1.5
+            },
+            {
+                "name": "selfVolume",
+                "value": 0.7
+            }
+        ]
+    },
+    {
+        "mixer": "OutputBusMixer",
+        "max": 80,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1.5
+            }
+        ]
+    }
   ],
-  "mixerOptions": {
-    "SelfVolumeMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        },
-        {
-            "name": "selfVolume",
-            "value": 0.7
-        }
-    ],
-    "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ]
-  },
   "preChain": [
       {
           "name": "GateLink",

--- a/presets/LargeGroupPreset/config.json
+++ b/presets/LargeGroupPreset/config.json
@@ -1,15 +1,16 @@
 {
   "id": "large-group",
   "label": "Large Group",
-  "mixerMax": [
-    { "SimpleMixer": 500 }
-  ],
-  "mixerOptions": {
-    "SimpleMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ]
-  }
+  "mixers": [
+    {
+        "mixer": "SimpleMixer",
+        "max": 500,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1.5
+            }
+        ]
+    }
+  ]
 }

--- a/presets/LargeGroupPreset/config.json
+++ b/presets/LargeGroupPreset/config.json
@@ -5,24 +5,6 @@
     { "SimpleMixer": 500 }
   ],
   "mixerOptions": {
-    "SelfVolumeMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ],
-    "PersonalMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ],
-    "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ],
     "SimpleMixer": [
         {
             "name": "masterVolume",

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -1,21 +1,22 @@
 {
   "id": "mic-test",
   "label": "Microphone Test",
-  "mixerMax": [
-    { "SelfVolumeMixer": 180 }
+  "mixers": [
+    {
+        "mixer": "SelfVolumeMixer",
+        "max": 180,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 0.5
+            },
+            {
+                "name": "selfVolume",
+                "value": 3
+            }
+        ]
+    }
   ],
-  "mixerOptions": {
-    "SelfVolumeMixer": [
-        {
-            "name": "masterVolume",
-            "value": 0.5
-        },
-        {
-            "name": "selfVolume",
-            "value": 3
-        }
-    ]
-  },
   "preChain": [
     {
         "name": "GateLink",

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -14,28 +14,6 @@
             "name": "selfVolume",
             "value": 3
         }
-    ],
-    "PersonalMixer": [
-        {
-            "name": "masterVolume",
-            "value": 0.5
-        },
-        {
-            "name": "selfVolume",
-            "value": 3
-        }
-    ],
-    "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1
-        }
-    ],
-    "SimpleMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1
-        }
     ]
   },
   "preChain": [

--- a/presets/RawStereoPreset/config.json
+++ b/presets/RawStereoPreset/config.json
@@ -1,28 +1,32 @@
 {
   "id": "raw-stereo",
   "label": "Raw Stereo",
-  "mixerMax": [
-    { "SelfVolumeMixer": 180 },
-    { "OutputBusMixer": 180 }
+  "mixers": [
+    {
+        "mixer": "SelfVolumeMixer",
+        "max": 180,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1
+            },
+            {
+                "name": "selfVolume",
+                "value": 0
+            }
+        ]
+    },
+    {
+        "mixer": "OutputBusMixer",
+        "max": 180,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1
+            }
+        ]
+    }
   ],
-  "mixerOptions": {
-    "SelfVolumeMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1
-        },
-        {
-            "name": "selfVolume",
-            "value": 0
-        }
-    ],
-    "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1
-        }
-    ]
-  },
   "preChain": [
     {
         "name": "GateLink",

--- a/presets/RawStereoPreset/config.json
+++ b/presets/RawStereoPreset/config.json
@@ -16,23 +16,7 @@
             "value": 0
         }
     ],
-    "PersonalMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1
-        },
-        {
-            "name": "selfVolume",
-            "value": 0
-        }
-    ],
     "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1
-        }
-    ],
-    "SimpleMixer": [
         {
             "name": "masterVolume",
             "value": 1

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -1,28 +1,32 @@
 {
   "id": "rehearsal-room",
   "label": "Rehearsal Room",
-  "mixerMax": [
-    { "SelfVolumeMixer": 20 },
-    { "OutputBusMixer": 80 }
+  "mixers": [
+    {
+        "mixer": "SelfVolumeMixer",
+        "max": 20,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1.5
+            },
+            {
+                "name": "selfVolume",
+                "value": 0.2
+            }
+        ]
+    },
+    {
+        "mixer": "OutputBusMixer",
+        "max": 80,
+        "options": [
+            {
+                "name": "masterVolume",
+                "value": 1.5
+            }
+        ]
+    }
   ],
-  "mixerOptions": {
-    "SelfVolumeMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        },
-        {
-            "name": "selfVolume",
-            "value": 0.2
-        }
-    ],
-    "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ]
-  },
   "preChain": [
       {
           "name": "GateLink",

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -16,23 +16,7 @@
             "value": 0.2
         }
     ],
-    "PersonalMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        },
-        {
-            "name": "selfVolume",
-            "value": 0.2
-        }
-    ],
     "OutputBusMixer": [
-        {
-            "name": "masterVolume",
-            "value": 1.5
-        }
-    ],
-    "SimpleMixer": [
         {
             "name": "masterVolume",
             "value": 1.5


### PR DESCRIPTION
Reformats the mixer presets to a cleaner format. The `mixerMax` and `mixerOptions` have been combined into a single array under the `mixers` field.

```
"mixers": [
    "mixer": "SimpleMixer",
    "max": 20,
    "options": [
        {
            "name": "masterVolume",
            "value": 1.5
        }
    ]
]
```
