### PR TITLE
Bump max concurrent clients to 40 for most expensive presets

### DIFF
--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -4,7 +4,7 @@
   "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
-        "max": 20,
+        "max": 40,
         "options": [
             {
                 "name": "masterVolume",

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -4,7 +4,7 @@
   "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
-        "max": 20,
+        "max": 40,
         "options": [
             {
                 "name": "masterVolume",

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -4,7 +4,7 @@
   "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
-        "max": 20,
+        "max": 40,
         "options": [
             {
                 "name": "masterVolume",


### PR DESCRIPTION
After more testing, more supernova threads can support higher numbers