### PR TITLE
Fix for self volume when master volume != 1.0

### DIFF
--- a/mixers/SelfVolumeMixer/SelfVolumeMixer.sc
+++ b/mixers/SelfVolumeMixer/SelfVolumeMixer.sc
@@ -98,7 +98,7 @@ SelfVolumeMixer : InputBusMixer {
                         extraSelfVolume = selfVolume - 1.0;
                     });
                 });
-                args = args ++ [\extraSelfVolume, extraSelfVolume];
+                args = args ++ [\extraSelfVolume, extraSelfVolume * masterVolume];
 
                 // create personal output synth
                 if(bypassFx==1, {


### PR DESCRIPTION
I forgot to multiply by masterVolume, which caused selfVolume to not work properly unless master volume == 1.0