### PR TITLE
Adding pan range settings to presets

### DIFF
--- a/presets/CathedralPreset/config.json
+++ b/presets/CathedralPreset/config.json
@@ -1,7 +1,7 @@
 {
-  "id": "cathedral",
-  "label": "Cathedral",
-  "mixerConfigs": [
+    "id": "cathedral",
+    "label": "Cathedral",
+    "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
         "max": 40,
@@ -34,117 +34,111 @@
             }
         ]
     }
-  ],
-  "preChain": [
-      {
-          "name": "GateLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -60
-              },
-              {
-                  "name": "attack",
-                  "value": 0.01
-              },
-              {
-                  "name": "release",
-                  "value": 0.3
-              },
-              {
-                  "name": "range",
-                  "value": 10
-              }
-          ]
-      },
-      {
-          "name": "MultiplyLink",
-          "options": [
-              {
-                  "name": "factor",
-                  "value": 1.5
-              }
-          ]
-      },
-      {
-          "name": "BandPassFilterLink",
-          "options": [
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      95.49925860214358,
-                      11481.536214968817
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "PanningLink",
-          "options": [
-              {
-                  "name": "panSlots",
-                  "value": 9
-              },
-              {
-                "names": [
-                  "left",
-                  "right"
-                ],
-                "values": [
-                  -0.5,
-                  0.5
-                ]
-              }
-          ]
-      }
-  ],
-  "postChain": [
-      {
-          "name": "ConvReverbLink",
-          "options": [
-              {
-                  "name": "irPath",
-                  "value": "/var/lib/jacktrip/impulses/EchoThiefImpulseResponseLibrary/Underground/SquareVictoriaDome.wav"
-              },
-              {
-                  "name": "mix",
-                  "value": 0.029546088884793393
-              },
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      199.52623149688787,
-                      6416.526614874055
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "LimiterLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -10
-              },
-              {
-                  "name": "attack",
-                  "value": 0.002
-              },
-              {
-                  "name": "release",
-                  "value": 0.01
-              },
-              {
-                  "name": "ratio",
-                  "value": 0.033
-              }
-          ]
-      }
-  ]
+    ],
+    "preChain": [
+        {
+            "name": "GateLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -60
+                },
+                {
+                    "name": "attack",
+                    "value": 0.01
+                },
+                {
+                    "name": "release",
+                    "value": 0.3
+                },
+                {
+                    "name": "range",
+                    "value": 10
+                }
+            ]
+        },
+        {
+            "name": "MultiplyLink",
+            "options": [
+                {
+                    "name": "factor",
+                    "value": 1.5
+                }
+            ]
+        },
+        {
+            "name": "BandPassFilterLink",
+            "options": [
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        95.49925860214358,
+                        11481.536214968817
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "PanningLink",
+            "options": [
+                {
+                    "name": "panSlots",
+                    "value": 9
+                },
+                {
+                    "names": ["left", "right"],
+                    "values": [-0.5, 0.5]
+                }
+            ]
+        }
+    ],
+    "postChain": [
+        {
+            "name": "ConvReverbLink",
+            "options": [
+                {
+                    "name": "irPath",
+                    "value": "/var/lib/jacktrip/impulses/EchoThiefImpulseResponseLibrary/Underground/SquareVictoriaDome.wav"
+                },
+                {
+                    "name": "mix",
+                    "value": 0.029546088884793393
+                },
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        199.52623149688787,
+                        6416.526614874055
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "LimiterLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -10
+                },
+                {
+                    "name": "attack",
+                    "value": 0.002
+                },
+                {
+                    "name": "release",
+                    "value": 0.01
+                },
+                {
+                    "name": "ratio",
+                    "value": 0.033
+                }
+            ]
+        }
+    ]
 }

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -1,7 +1,7 @@
 {
-  "id": "default-mix",
-  "label": "Standard",
-  "mixerConfigs": [
+    "id": "default-mix",
+    "label": "Standard",
+    "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
         "max": 40,
@@ -34,128 +34,132 @@
             }
         ]
     }
-  ],
-  "preChain": [
-      {
-          "name": "GateLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -60
-              },
-              {
-                  "name": "attack",
-                  "value": 0.01
-              },
-              {
-                  "name": "release",
-                  "value": 0.3
-              },
-              {
-                  "name": "range",
-                  "value": 10
-              }
-          ]
-      },
-      {
-          "name": "MultiplyLink",
-          "options": [
-              {
-                  "name": "factor",
-                  "value": 2
-              }
-          ]
-      },
-      {
-          "name": "BandPassFilterLink",
-          "options": [
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      100.66998409579647,
-                      20000.000000000004
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "CompressorLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -30
-              },
-              {
-                  "name": "attack",
-                  "value": 0.01
-              },
-              {
-                  "name": "release",
-                  "value": 0.02
-              },
-              {
-                  "name": "ratio",
-                  "value": 0.667
-              }
-          ]
-      },
-      {
-          "name": "PanningLink",
-          "options": [
-              {
-                  "name": "panSlots",
-                  "value": 1
-              }
-          ]
-      }
-  ],
-  "postChain": [
-      {
-          "name": "ConvReverbLink",
-          "options": [
-              {
-                  "name": "irPath",
-                  "value": "/var/lib/jacktrip/impulses/IMreverbs/Nice Drum Room.wav"
-              },
-              {
-                  "name": "mix",
-                  "value": 0.02
-              },
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      300.0000000000001,
-                      9993.094630025895
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "LimiterLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -10
-              },
-              {
-                  "name": "attack",
-                  "value": 0.002
-              },
-              {
-                  "name": "release",
-                  "value": 0.01
-              },
-              {
-                  "name": "ratio",
-                  "value": 0.033
-              }
-          ]
-      }
-  ]
+    ],
+    "preChain": [
+        {
+            "name": "GateLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -60
+                },
+                {
+                    "name": "attack",
+                    "value": 0.01
+                },
+                {
+                    "name": "release",
+                    "value": 0.3
+                },
+                {
+                    "name": "range",
+                    "value": 10
+                }
+            ]
+        },
+        {
+            "name": "MultiplyLink",
+            "options": [
+                {
+                    "name": "factor",
+                    "value": 2
+                }
+            ]
+        },
+        {
+            "name": "BandPassFilterLink",
+            "options": [
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        100.66998409579647,
+                        20000.000000000004
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "CompressorLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -30
+                },
+                {
+                    "name": "attack",
+                    "value": 0.01
+                },
+                {
+                    "name": "release",
+                    "value": 0.02
+                },
+                {
+                    "name": "ratio",
+                    "value": 0.667
+                }
+            ]
+        },
+        {
+            "name": "PanningLink",
+            "options": [
+                {
+                    "name": "panSlots",
+                    "value": 1
+                },
+                {
+                    "names": ["left", "right"],
+                    "values": [-0.5, 0.5]
+                }
+            ]
+        }
+    ],
+    "postChain": [
+        {
+            "name": "ConvReverbLink",
+            "options": [
+                {
+                    "name": "irPath",
+                    "value": "/var/lib/jacktrip/impulses/IMreverbs/Nice Drum Room.wav"
+                },
+                {
+                    "name": "mix",
+                    "value": 0.02
+                },
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        300.0000000000001,
+                        9993.094630025895
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "LimiterLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -10
+                },
+                {
+                    "name": "attack",
+                    "value": 0.002
+                },
+                {
+                    "name": "release",
+                    "value": 0.01
+                },
+                {
+                    "name": "ratio",
+                    "value": 0.033
+                }
+            ]
+        }
+    ]
 }

--- a/presets/DryRoomPreset/config.json
+++ b/presets/DryRoomPreset/config.json
@@ -1,7 +1,7 @@
 {
-  "id": "dry-room",
-  "label": "Dry Room",
-  "mixerConfigs": [
+    "id": "dry-room",
+    "label": "Dry Room",
+    "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
         "max": 120,
@@ -34,52 +34,56 @@
             }
         ]
     }
-  ],
-  "preChain": [
-      {
-          "name": "GateLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -60
-              },
-              {
-                  "name": "attack",
-                  "value": 0.01
-              },
-              {
-                  "name": "release",
-                  "value": 0.3
-              },
-              {
-                  "name": "range",
-                  "value": 10
-              }
-          ]
-      },
-      {
-          "name": "BandPassFilterLink",
-          "options": [
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      100.66998409579647,
-                      20000.000000000004
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "PanningLink",
-          "options": [
-              {
-                  "name": "panSlots",
-                  "value": 1
-              }
-          ]
-      }
-  ]
+    ],
+    "preChain": [
+        {
+            "name": "GateLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -60
+                },
+                {
+                    "name": "attack",
+                    "value": 0.01
+                },
+                {
+                    "name": "release",
+                    "value": 0.3
+                },
+                {
+                    "name": "range",
+                    "value": 10
+                }
+            ]
+        },
+        {
+            "name": "BandPassFilterLink",
+            "options": [
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        100.66998409579647,
+                        20000.000000000004
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "PanningLink",
+            "options": [
+                {
+                    "name": "panSlots",
+                    "value": 1
+                },
+                {
+                    "names": ["left", "right"],
+                    "values": [-0.5, 0.5]
+                }
+            ]
+        }
+    ]
 }

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -1,7 +1,7 @@
 {
-  "id": "echo-hall",
-  "label": "Echo Hall",
-  "mixerConfigs": [
+    "id": "echo-hall",
+    "label": "Echo Hall",
+    "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
         "max": 40,
@@ -34,107 +34,111 @@
             }
         ]
     }
-  ],
-  "preChain": [
-      {
-          "name": "GateLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -60
-              },
-              {
-                  "name": "attack",
-                  "value": 0.01
-              },
-              {
-                  "name": "release",
-                  "value": 0.3
-              },
-              {
-                  "name": "range",
-                  "value": 10
-              }
-          ]
-      },
-      {
-          "name": "MultiplyLink",
-          "options": [
-              {
-                  "name": "factor",
-                  "value": 1.5
-              }
-          ]
-      },
-      {
-          "name": "BandPassFilterLink",
-          "options": [
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      100.48471382465803,
-                      11992.231400236049
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "PanningLink",
-          "options": [
-              {
-                  "name": "panSlots",
-                  "value": 9
-              }
-          ]
-      }
-  ],
-  "postChain": [
-      {
-          "name": "ConvReverbLink",
-          "options": [
-              {
-                  "name": "irPath",
-                  "value": "/var/lib/jacktrip/impulses/IMreverbs/Large Wide Echo Hall.wav"
-              },
-              {
-                  "name": "mix",
-                  "value": 0.05
-              },
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      198.107081487124,
-                      9038.575706601763
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "LimiterLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -10
-              },
-              {
-                  "name": "attack",
-                  "value": 0.002
-              },
-              {
-                  "name": "release",
-                  "value": 0.01
-              },
-              {
-                  "name": "ratio",
-                  "value": 0.033
-              }
-          ]
-      }
-  ]
+    ],
+    "preChain": [
+        {
+            "name": "GateLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -60
+                },
+                {
+                    "name": "attack",
+                    "value": 0.01
+                },
+                {
+                    "name": "release",
+                    "value": 0.3
+                },
+                {
+                    "name": "range",
+                    "value": 10
+                }
+            ]
+        },
+        {
+            "name": "MultiplyLink",
+            "options": [
+                {
+                    "name": "factor",
+                    "value": 1.5
+                }
+            ]
+        },
+        {
+            "name": "BandPassFilterLink",
+            "options": [
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        100.48471382465803,
+                        11992.231400236049
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "PanningLink",
+            "options": [
+                {
+                    "name": "panSlots",
+                    "value": 9
+                },
+                {
+                    "names": ["left", "right"],
+                    "values": [-0.5, 0.5]
+                }
+            ]
+        }
+    ],
+    "postChain": [
+        {
+            "name": "ConvReverbLink",
+            "options": [
+                {
+                    "name": "irPath",
+                    "value": "/var/lib/jacktrip/impulses/IMreverbs/Large Wide Echo Hall.wav"
+                },
+                {
+                    "name": "mix",
+                    "value": 0.05
+                },
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        198.107081487124,
+                        9038.575706601763
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "LimiterLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -10
+                },
+                {
+                    "name": "attack",
+                    "value": 0.002
+                },
+                {
+                    "name": "release",
+                    "value": 0.01
+                },
+                {
+                    "name": "ratio",
+                    "value": 0.033
+                }
+            ]
+        }
+    ]
 }

--- a/presets/EtherealEchoPreset/config.json
+++ b/presets/EtherealEchoPreset/config.json
@@ -1,7 +1,7 @@
 {
-  "id": "ethereal-echo-chamber",
-  "label": "Ethereal Echo Chamber",
-  "mixerConfigs": [
+    "id": "ethereal-echo-chamber",
+    "label": "Ethereal Echo Chamber",
+    "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
         "max": 40,
@@ -34,117 +34,111 @@
             }
         ]
     }
-  ],
-  "preChain": [
-      {
-          "name": "GateLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -60
-              },
-              {
-                  "name": "attack",
-                  "value": 0.01
-              },
-              {
-                  "name": "release",
-                  "value": 0.3
-              },
-              {
-                  "name": "range",
-                  "value": 10
-              }
-          ]
-      },
-      {
-          "name": "MultiplyLink",
-          "options": [
-              {
-                  "name": "factor",
-                  "value": 1.5
-              }
-          ]
-      },
-      {
-          "name": "BandPassFilterLink",
-          "options": [
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      100.53099940231341,
-                      15488.166189124828
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "PanningLink",
-          "options": [
-              {
-                  "name": "panSlots",
-                  "value": 9
-              },
-              {
-                "names": [
-                  "left",
-                  "right"
-                ],
-                "values": [
-                  -0.5,
-                  0.5
-                ]
-              }
-          ]
-      }
-  ],
-  "postChain": [
-      {
-          "name": "ConvReverbLink",
-          "options": [
-              {
-                  "name": "irPath",
-                  "value": "/var/lib/jacktrip/impulses/EchoThiefImpulseResponseLibrary/Underpasses/EchoBridge.wav"
-              },
-              {
-                  "name": "mix",
-                  "value": 0.049670667922342274
-              },
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      199.52623149688787,
-                      6416.526614874055
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "LimiterLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -10
-              },
-              {
-                  "name": "attack",
-                  "value": 0.002
-              },
-              {
-                  "name": "release",
-                  "value": 0.01
-              },
-              {
-                  "name": "ratio",
-                  "value": 0.033
-              }
-          ]
-      }
-  ]
+    ],
+    "preChain": [
+        {
+            "name": "GateLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -60
+                },
+                {
+                    "name": "attack",
+                    "value": 0.01
+                },
+                {
+                    "name": "release",
+                    "value": 0.3
+                },
+                {
+                    "name": "range",
+                    "value": 10
+                }
+            ]
+        },
+        {
+            "name": "MultiplyLink",
+            "options": [
+                {
+                    "name": "factor",
+                    "value": 1.5
+                }
+            ]
+        },
+        {
+            "name": "BandPassFilterLink",
+            "options": [
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        100.53099940231341,
+                        15488.166189124828
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "PanningLink",
+            "options": [
+                {
+                    "name": "panSlots",
+                    "value": 9
+                },
+                {
+                    "names": ["left", "right"],
+                    "values": [-0.5, 0.5]
+                }
+            ]
+        }
+    ],
+    "postChain": [
+        {
+            "name": "ConvReverbLink",
+            "options": [
+                {
+                    "name": "irPath",
+                    "value": "/var/lib/jacktrip/impulses/EchoThiefImpulseResponseLibrary/Underpasses/EchoBridge.wav"
+                },
+                {
+                    "name": "mix",
+                    "value": 0.049670667922342274
+                },
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        199.52623149688787,
+                        6416.526614874055
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "LimiterLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -10
+                },
+                {
+                    "name": "attack",
+                    "value": 0.002
+                },
+                {
+                    "name": "release",
+                    "value": 0.01
+                },
+                {
+                    "name": "ratio",
+                    "value": 0.033
+                }
+            ]
+        }
+    ]
 }

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -1,7 +1,7 @@
 {
-  "id": "mic-test",
-  "label": "Microphone Test",
-  "mixerConfigs": [
+    "id": "mic-test",
+    "label": "Microphone Test",
+    "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
         "max": 180,
@@ -20,60 +20,64 @@
             }
         ]
     }
-  ],
-  "preChain": [
+    ],
+    "preChain": [
     {
         "name": "GateLink",
         "options": [
-              {
-                  "name": "thresh",
-                  "value": -60
-              },
-              {
-                  "name": "attack",
-                  "value": 0.01
-              },
-              {
-                  "name": "release",
-                  "value": 0.3
-              },
-              {
-                  "name": "range",
-                  "value": 10
-              }
-          ]
-      },
-      {
-          "name": "PanningLink",
-          "options": [
-              {
-                  "name": "panSlots",
-                  "value": 1
-              }
-          ]
-      }
-  ],
-  "postChain": [
-      {
-          "name": "LimiterLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -10
-              },
-              {
-                  "name": "attack",
-                  "value": 0.002
-              },
-              {
-                  "name": "release",
-                  "value": 0.01
-              },
-              {
-                  "name": "ratio",
-                  "value": 0.033
-              }
-          ]
-      }
-  ]
+                {
+                    "name": "thresh",
+                    "value": -60
+                },
+                {
+                    "name": "attack",
+                    "value": 0.01
+                },
+                {
+                    "name": "release",
+                    "value": 0.3
+                },
+                {
+                    "name": "range",
+                    "value": 10
+                }
+            ]
+        },
+        {
+            "name": "PanningLink",
+            "options": [
+                {
+                    "name": "panSlots",
+                    "value": 1
+                },
+                {
+                    "names": ["left", "right"],
+                    "values": [-0.5, 0.5]
+                }
+            ]
+        }
+    ],
+    "postChain": [
+        {
+            "name": "LimiterLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -10
+                },
+                {
+                    "name": "attack",
+                    "value": 0.002
+                },
+                {
+                    "name": "release",
+                    "value": 0.01
+                },
+                {
+                    "name": "ratio",
+                    "value": 0.033
+                }
+            ]
+        }
+    ]
 }

--- a/presets/RawStereoPreset/config.json
+++ b/presets/RawStereoPreset/config.json
@@ -1,7 +1,7 @@
 {
-  "id": "raw-stereo",
-  "label": "Raw Stereo",
-  "mixerConfigs": [
+    "id": "raw-stereo",
+    "label": "Raw Stereo",
+    "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
         "max": 180,
@@ -34,51 +34,51 @@
             }
         ]
     }
-  ],
-  "preChain": [
+    ],
+    "preChain": [
     {
         "name": "GateLink",
         "options": [
-              {
-                  "name": "thresh",
-                  "value": -60
-              },
-              {
-                  "name": "attack",
-                  "value": 0.01
-              },
-              {
-                  "name": "release",
-                  "value": 0.3
-              },
-              {
-                  "name": "range",
-                  "value": 10
-              }
-          ]
-      }
-  ],
-  "postChain": [
-      {
-          "name": "LimiterLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -10
-              },
-              {
-                  "name": "attack",
-                  "value": 0.002
-              },
-              {
-                  "name": "release",
-                  "value": 0.01
-              },
-              {
-                  "name": "ratio",
-                  "value": 0.033
-              }
-          ]
-      }
-  ]
+                {
+                    "name": "thresh",
+                    "value": -60
+                },
+                {
+                    "name": "attack",
+                    "value": 0.01
+                },
+                {
+                    "name": "release",
+                    "value": 0.3
+                },
+                {
+                    "name": "range",
+                    "value": 10
+                }
+            ]
+        }
+    ],
+    "postChain": [
+        {
+            "name": "LimiterLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -10
+                },
+                {
+                    "name": "attack",
+                    "value": 0.002
+                },
+                {
+                    "name": "release",
+                    "value": 0.01
+                },
+                {
+                    "name": "ratio",
+                    "value": 0.033
+                }
+            ]
+        }
+    ]
 }

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -1,7 +1,7 @@
 {
-  "id": "rehearsal-room",
-  "label": "Rehearsal Room",
-  "mixerConfigs": [
+    "id": "rehearsal-room",
+    "label": "Rehearsal Room",
+    "mixerConfigs": [
     {
         "name": "SelfVolumeMixer",
         "max": 40,
@@ -34,107 +34,111 @@
             }
         ]
     }
-  ],
-  "preChain": [
-      {
-          "name": "GateLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -60
-              },
-              {
-                  "name": "attack",
-                  "value": 0.01
-              },
-              {
-                  "name": "release",
-                  "value": 0.3
-              },
-              {
-                  "name": "range",
-                  "value": 10
-              }
-          ]
-      },
-      {
-          "name": "MultiplyLink",
-          "options": [
-              {
-                  "name": "factor",
-                  "value": 1.5
-              }
-          ]
-      },
-      {
-          "name": "BandPassFilterLink",
-          "options": [
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      100.48471382465803,
-                      15021.039909500785
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "PanningLink",
-          "options": [
-              {
-                  "name": "panSlots",
-                  "value": 9
-              }
-          ]
-      }
-  ],
-  "postChain": [
-      {
-          "name": "ConvReverbLink",
-          "options": [
-              {
-                  "name": "irPath",
-                  "value": "/var/lib/jacktrip/impulses/IMreverbs/French 18th Century Salon.wav"
-              },
-              {
-                  "name": "mix",
-                  "value": 0.02
-              },
-              {
-                  "names": [
-                      "low",
-                      "high"
-                  ],
-                  "values": [
-                      300,
-                      6000
-                  ]
-              }
-          ]
-      },
-      {
-          "name": "LimiterLink",
-          "options": [
-              {
-                  "name": "thresh",
-                  "value": -10
-              },
-              {
-                  "name": "attack",
-                  "value": 0.002
-              },
-              {
-                  "name": "release",
-                  "value": 0.01
-              },
-              {
-                  "name": "ratio",
-                  "value": 0.033
-              }
-          ]
-      }
-  ]
+    ],
+    "preChain": [
+        {
+            "name": "GateLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -60
+                },
+                {
+                    "name": "attack",
+                    "value": 0.01
+                },
+                {
+                    "name": "release",
+                    "value": 0.3
+                },
+                {
+                    "name": "range",
+                    "value": 10
+                }
+            ]
+        },
+        {
+            "name": "MultiplyLink",
+            "options": [
+                {
+                    "name": "factor",
+                    "value": 1.5
+                }
+            ]
+        },
+        {
+            "name": "BandPassFilterLink",
+            "options": [
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        100.48471382465803,
+                        15021.039909500785
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "PanningLink",
+            "options": [
+                {
+                    "name": "panSlots",
+                    "value": 9
+                },
+                {
+                    "names": ["left", "right"],
+                    "values": [-0.5, 0.5]
+                }
+            ]
+        }
+    ],
+    "postChain": [
+        {
+            "name": "ConvReverbLink",
+            "options": [
+                {
+                    "name": "irPath",
+                    "value": "/var/lib/jacktrip/impulses/IMreverbs/French 18th Century Salon.wav"
+                },
+                {
+                    "name": "mix",
+                    "value": 0.02
+                },
+                {
+                    "names": [
+                        "low",
+                        "high"
+                    ],
+                    "values": [
+                        300,
+                        6000
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "LimiterLink",
+            "options": [
+                {
+                    "name": "thresh",
+                    "value": -10
+                },
+                {
+                    "name": "attack",
+                    "value": 0.002
+                },
+                {
+                    "name": "release",
+                    "value": 0.01
+                },
+                {
+                    "name": "ratio",
+                    "value": 0.033
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
It seems that UI only displays parameters which explicitly defined by the presets. The pan range parameter was added after some of the presets were created, so the sliders are not shown. I added the parameter to the presets so that they will be shown in the interface, in case anyone wants to change it.

I also fixed inconsistent formatting of the JSON, where it was first indenting by 2 spaces, and then 4.