### PR TITLE
Fix for Jamulus users with SelfVolumeMixer

### DIFF
--- a/synthdefs/JackTripDownMixOut.scd
+++ b/synthdefs/JackTripDownMixOut.scd
@@ -37,9 +37,8 @@
         // the fact that jamulus will be echoing back to all users already
         // this ensures that they will hear the same thing as jacktrip users
         var jamulusSignal = JackTripInput(1, inputChannelsPerClient, false, ~firstPrivateBus).getSignal();
-        jamulusSignal = signal ++ jamulusSignal;
-        jamulusSignal = MulAdd(jamulusSignal, [1.0, -1.0], 0);
-        jamulusSignal = AggregateLink().ar(jamulusSignal);
+        jamulusSignal = MulAdd(jamulusSignal, -1.0, 0);
+        jamulusSignal = MulAdd(signal, 1.0, jamulusSignal[0]);
         Out.ar(0, jamulusSignal);
         masterOut.removeAt(0);
     });

--- a/synthdefs/JackTripSelfVolumeMixOut.scd
+++ b/synthdefs/JackTripSelfVolumeMixOut.scd
@@ -21,8 +21,8 @@
  * \inputChannelsPerClient: number of input channels received from each client
  * \outputChannelsPerClient: number of output channels sent to each client
  * \withJamulus: create mixes adapted Jamulus being connected on channels 1 & 2
- * \mix : array of amplitude level multipliers (default 1.0) for each client
- * \mul : master amplitude level multiplier (default 1.0)
+ * \masterVolume : master amplitude level multiplier (default 1.0)
+ * \extraSelfVolume : amount of additional volume multiplied by self
  */
 
 ~synthDef = { | maxClients, preChain, postChain, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |

--- a/synthdefs/JamulusDownMixOut.scd
+++ b/synthdefs/JamulusDownMixOut.scd
@@ -15,34 +15,26 @@
  */
  
  /*
- * JackTripDownMixOut: a minimal mix that scales well and reads from input busses
+ * JamulusDownMixOut: a minimal mix for Jamulus that scales well and reads from input busses
  *
  * \maxClients: maximum number of clients that may connect to the audio server
  * \inputChannelsPerClient: number of input channels received from each client
  * \outputChannelsPerClient: number of output channels sent to each client
- * \withJamulus: create mixes adapted Jamulus being connected on channels 1 & 2
- * \mul : master amplitude level multiplier (default 1.0)
+ * \masterVolume : master amplitude level multiplier (default 1.0)
  */
 
 ~synthDef = { | maxClients, preChain, postChain, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    var masterOut = Array.fill(maxClients, { |n| n * outputChannelsPerClient; });
-
     var signal = JackTripInput(1, inputChannelsPerClient, false, ~masterInputBus).getSignal();
-    signal = MulAdd(signal, \mul.kr(1.0), 0);
+    signal = MulAdd(signal, \masterVolume.kr(1.0), 0);
     signal = AggregateLink().ar(signal);
     signal = postChain.ar(signal);
 
-    if (withJamulus, {
-        // remove source jamulus signal from the result to offset
-        // the fact that jamulus will be echoing back to all users already
-        // this ensures that they will hear the same thing as jacktrip users
-        var jamulusSignal = JackTripInput(1, inputChannelsPerClient, false, ~firstPrivateBus).getSignal();
-        jamulusSignal = signal ++ jamulusSignal;
-        jamulusSignal = MulAdd(jamulusSignal, [1.0, -1.0], 0);
-        jamulusSignal = AggregateLink().ar(jamulusSignal);
-        Out.ar(0, jamulusSignal);
-        masterOut.removeAt(0);
-    });
+    // remove source jamulus signal from the result to offset
+    // the fact that jamulus will be echoing back to all users already
+    // this ensures that they will hear the same thing as jacktrip users
+    signal = signal ++ JackTripInput(1, inputChannelsPerClient, false, ~firstPrivateBus).getSignal();
+    signal = MulAdd(signal, [1.0, -1.0], 0);
+    signal = AggregateLink().ar(signal);
 
-    Out.ar(masterOut, signal);
+    Out.ar(0, signal);
 };

--- a/synthdefs/JamulusDownMixOut.scd
+++ b/synthdefs/JamulusDownMixOut.scd
@@ -24,7 +24,9 @@
  */
 
 ~synthDef = { | maxClients, preChain, postChain, inputChannelsPerClient = 2, outputChannelsPerClient = 2, withJamulus = false |
-    var signal = JackTripInput(1, inputChannelsPerClient, false, ~masterInputBus).getSignal();
+    var signal, jamulusSignal;
+    
+    signal = JackTripInput(1, inputChannelsPerClient, false, ~masterInputBus).getSignal();
     signal = MulAdd(signal, \masterVolume.kr(1.0), 0);
     signal = AggregateLink().ar(signal);
     signal = postChain.ar(signal);
@@ -32,9 +34,9 @@
     // remove source jamulus signal from the result to offset
     // the fact that jamulus will be echoing back to all users already
     // this ensures that they will hear the same thing as jacktrip users
-    signal = signal ++ JackTripInput(1, inputChannelsPerClient, false, ~firstPrivateBus).getSignal();
-    signal = MulAdd(signal, [1.0, -1.0], 0);
-    signal = AggregateLink().ar(signal);
-
-    Out.ar(0, signal);
+    jamulusSignal = JackTripInput(1, inputChannelsPerClient, false, ~firstPrivateBus).getSignal();
+    jamulusSignal = MulAdd(jamulusSignal, -1.0, 0);
+    jamulusSignal = MulAdd(signal, 1.0, jamulusSignal[0]);
+    
+    Out.ar(0, jamulusSignal);
 };


### PR DESCRIPTION
Previous logic for Jamulus users was a bit weird:

* Jamulus users would only ever hear their dry signal at 1.0 volume, regardless of what master volume was set. Everyone else would hear them scaled to master volume.

* Jamulus users would never hear any effects on their audio, but they would hear effects on JackTrip user audio. JackTrip users would hear effects on all audio.

Also fixes for OutputBusMixer so that it behaves the same as SelfVolumeMixer, for Jamulus users.