### PR TITLE
[WIP] Feature/add metronome and tuning note

### DIFF
--- a/links/MetronomeLink/MetronomeLink.sc
+++ b/links/MetronomeLink/MetronomeLink.sc
@@ -31,15 +31,15 @@ MetronomeLink : Link {
         var signal = input;
         var osc, trg;
 
-        trg = Decay2.ar(Impulse.ar(bpm/60, 0, 0.3), 0.01, 0.3);
+        trg = Decay2.ar(Impulse.ar(\metronome_bpm.ar(bpm)/60, 0, 0.3), 0.01, 0.3);
         osc = {WhiteNoise.ar(trg)}.dup;
 
-        signal = MulAdd(osc, vol, signal);
+        signal = MulAdd(osc, \metronome_vol.ar(vol), signal);
         ^signal;
     }
 
     // returns a list of synth arguments used by this Link
     getArgs {
-        ^[\bpm, bpm, \vol, vol];
+        ^[\metronome_bpm, bpm, \metronome_vol, vol];
     }
 }

--- a/links/MetronomeLink/MetronomeLink.sc
+++ b/links/MetronomeLink/MetronomeLink.sc
@@ -35,7 +35,7 @@ MetronomeLink : Link {
         trg = Decay2.ar(Impulse.ar(bpm/60, 0, 0.3), 0.01, 0.3);
         osc = {WhiteNoise.ar(trg)}.dup;
 
-        signal = MulAdd(signal, vol, osc);
+        signal = MulAdd(osc, vol, signal);
         ^signal;
     }
 

--- a/links/MetronomeLink/MetronomeLink.sc
+++ b/links/MetronomeLink/MetronomeLink.sc
@@ -22,9 +22,10 @@
 MetronomeLink : Link {
     var<> bpm;
     var<> freq;
+    var<> vol;
 
-    *new { | bpm = 90, freq=1200 |
-        ^super.new().bpm_(bpm).freq_(freq);
+    *new { | bpm = 90, freq=1200, vol=0.5 |
+        ^super.new().bpm_(bpm).freq_(freq).vol_(vol);
     }
 
     ar { | input, id = "" |
@@ -34,13 +35,12 @@ MetronomeLink : Link {
         trg = Decay2.ar(Impulse.ar(bpm/60, 0, 0.3), 0.01, 0.3);
         osc = {WhiteNoise.ar(trg)}.dup;
 
-        signal = signal + osc
-
+        signal = MulAdd(signal, vol, osc);
         ^signal;
     }
 
     // returns a list of synth arguments used by this Link
     getArgs {
-        ^[\bpm, bpm, \freq, freq];
+        ^[\bpm, bpm, \freq, freq, \vol, vol];
     }
 }

--- a/links/MetronomeLink/MetronomeLink.sc
+++ b/links/MetronomeLink/MetronomeLink.sc
@@ -1,0 +1,46 @@
+/* 
+ * Copyright 2022 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* 
+ * MetronomeLink: Adds a metronome to a signal
+ *
+ */
+
+MetronomeLink : Link {
+    var<> bpm;
+    var<> freq;
+
+    *new { | bpm = 90, freq=1200 |
+        ^super.new().bpm_(bpm).freq_(freq);
+    }
+
+    ar { | input, id = "" |
+        var signal = input;
+        var osc, trg;
+
+        trg = Decay2.ar(Impulse.ar(bpm/60, 0, 0.3), 0.01, 0.3);
+        osc = {WhiteNoise.ar(trg)}.dup;
+
+        signal = signal + osc
+
+        ^signal;
+    }
+
+    // returns a list of synth arguments used by this Link
+    getArgs {
+        ^[\bpm, bpm, \freq, freq];
+    }
+}

--- a/links/MetronomeLink/MetronomeLink.sc
+++ b/links/MetronomeLink/MetronomeLink.sc
@@ -21,11 +21,10 @@
 
 MetronomeLink : Link {
     var<> bpm;
-    var<> freq;
     var<> vol;
 
-    *new { | bpm = 90, freq=1200, vol=0.5 |
-        ^super.new().bpm_(bpm).freq_(freq).vol_(vol);
+    *new { | bpm = 90, vol = 0.5 |
+        ^super.new().bpm_(bpm).vol_(vol);
     }
 
     ar { | input, id = "" |
@@ -41,6 +40,6 @@ MetronomeLink : Link {
 
     // returns a list of synth arguments used by this Link
     getArgs {
-        ^[\bpm, bpm, \freq, freq, \vol, vol];
+        ^[\bpm, bpm, \vol, vol];
     }
 }

--- a/links/MetronomeLink/config.json
+++ b/links/MetronomeLink/config.json
@@ -1,6 +1,6 @@
 {
   "label": "Metronome",
-  "class": "LimiterLink",
+  "class": "MetronomeLink",
   "options": [
       {
           "src": "bpm",

--- a/links/MetronomeLink/config.json
+++ b/links/MetronomeLink/config.json
@@ -12,7 +12,7 @@
               "fieldOptions": {
                   "marks": [
                       {
-                          "value": 40,
+                          "value": 60,
                           "label": "40 bpm"
                       },
                       {
@@ -20,7 +20,7 @@
                           "label": "120 bpm"
                       },
                       {
-                        "value": 200,
+                        "value": 180,
                         "label": "200 bpm"
                       }
                   ],
@@ -31,6 +31,56 @@
                   "scale": 1
               }
           }
-      } 
+      },
+      {
+        "src": "freq",
+        "label": "Frequency (Hz)",
+        "type": "number",
+        "defaultVal": 1200,
+        "field": {
+          "type": "slider",
+          "fieldOptions": {
+              "marks": [
+                  {
+                      "value": 20,
+                      "label": "20Hz"
+                  },
+                  {
+                      "value": 20000,
+                      "label": "20kHz"
+                  }
+              ],
+              "logarithmic": true,
+              "min": 20,
+              "max": 20000
+          }
+      }
+    },
+    {
+      "src": "vol",
+      "label": "Volume",
+      "type": "number",
+      "defaultVal": 0.5,
+      "field": {
+        "type": "slider",
+        "fieldOptions": {
+            "marks": [
+                {
+                    "value": 1,
+                    "label": "Quieter"
+                },
+                {
+                    "value": 2,
+                    "label": "Louder"
+                }
+            ],
+            "logarithmic": false,
+            "min": 0,
+            "max": 3,
+            "step": 0.01,
+            "scale": 1
+        }
+      }
+    } 
   ]
 }

--- a/links/MetronomeLink/config.json
+++ b/links/MetronomeLink/config.json
@@ -33,54 +33,30 @@
           }
       },
       {
-        "src": "freq",
-        "label": "Frequency (Hz)",
+        "src": "vol",
+        "label": "Volume",
         "type": "number",
-        "defaultVal": 1200,
+        "defaultVal": 0.5,
         "field": {
           "type": "slider",
           "fieldOptions": {
               "marks": [
                   {
-                      "value": 20,
-                      "label": "20Hz"
+                      "value": 1,
+                      "label": "Quieter"
                   },
                   {
-                      "value": 20000,
-                      "label": "20kHz"
+                      "value": 2,
+                      "label": "Louder"
                   }
               ],
-              "logarithmic": true,
-              "min": 20,
-              "max": 20000
+              "logarithmic": false,
+              "min": 0,
+              "max": 3,
+              "step": 0.01,
+              "scale": 1
           }
-      }
-    },
-    {
-      "src": "vol",
-      "label": "Volume",
-      "type": "number",
-      "defaultVal": 0.5,
-      "field": {
-        "type": "slider",
-        "fieldOptions": {
-            "marks": [
-                {
-                    "value": 1,
-                    "label": "Quieter"
-                },
-                {
-                    "value": 2,
-                    "label": "Louder"
-                }
-            ],
-            "logarithmic": false,
-            "min": 0,
-            "max": 3,
-            "step": 0.01,
-            "scale": 1
         }
-      }
-    } 
+      } 
   ]
 }

--- a/links/MetronomeLink/config.json
+++ b/links/MetronomeLink/config.json
@@ -1,0 +1,36 @@
+{
+  "label": "Metronome",
+  "class": "LimiterLink",
+  "options": [
+      {
+          "src": "bpm",
+          "label": "BPM",
+          "type": "number",
+          "defaultVal": 90,
+          "field": {
+              "type": "slider",
+              "fieldOptions": {
+                  "marks": [
+                      {
+                          "value": 40,
+                          "label": "40 bpm"
+                      },
+                      {
+                          "value": 120,
+                          "label": "120 bpm"
+                      },
+                      {
+                        "value": 200,
+                        "label": "200 bpm"
+                      }
+                  ],
+                  "logarithmic": false,
+                  "min": 40,
+                  "max": 200,
+                  "step": 1,
+                  "scale": 1
+              }
+          }
+      } 
+  ]
+}

--- a/links/TuningNoteLink/TuningNoteLink.sc
+++ b/links/TuningNoteLink/TuningNoteLink.sc
@@ -29,13 +29,13 @@ TuningNoteLink : Link {
 
     ar { | input, id = "" |
         var signal = input;
-        var sine = SinOsc.ar(freq, mul: vol);
+        var sine = SinOsc.ar(\tuning_freq.ar(freq), mul: \tuning_vol.ar(vol));
         signal = MulAdd(signal, 1, sine);
         ^signal;
     }
 
     // returns a list of synth arguments used by this Link
     getArgs {
-        ^[\freq, freq, \vol, vol];
+        ^[\tuning_freq, freq, \tuning_vol, vol];
     }
 }

--- a/links/TuningNoteLink/TuningNoteLink.sc
+++ b/links/TuningNoteLink/TuningNoteLink.sc
@@ -1,0 +1,41 @@
+/* 
+ * Copyright 2022 JackTrip Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* 
+ * TuningNoteLink: Adds a tuning note to a signal at a specified frequency
+ *
+ */
+
+TuningNoteLink : Link {
+    var<> freq;
+    var<> vol;
+
+    *new { | freq=440, vol=0.5 |
+        ^super.new().freq_(freq).vol_(vol);
+    }
+
+    ar { | input, id = "" |
+        var signal = input;
+        var sine = SinOsc.ar(freq, mul: vol);
+        signal = MulAdd(signal, 1, sine);
+        ^signal;
+    }
+
+    // returns a list of synth arguments used by this Link
+    getArgs {
+        ^[\freq, freq, \vol, vol];
+    }
+}

--- a/links/TuningNoteLink/config.json
+++ b/links/TuningNoteLink/config.json
@@ -1,113 +1,113 @@
 {
-  "label": "Tuning Note",
-  "class": "TuningNoteLink",
-  "options": [
-      {
-          "src": "freq",
-          "label": "Frequency",
-          "type": "number",
-          "defaultVal": 440,
-          "field": {
-              "type": "dropdown",
-              "fieldOptions": {
-                "labels": [
-                    {
-                        "value": 174.61,
-                        "label": "F (174.61 Hz)"
-                    },
-                    {
-                        "value": 185.00,
-                        "label": "F#/Gb (185.00 Hz)"
-                    },
-                    {
-                        "value": 196.00,
-                        "label": "G (196.00 Hz)"
-                    },
-                    {
-                        "value": 207.65,
-                        "label": "G#/Ab (207.65 Hz)"
-                    },
-                    {
-                        "value": 220.00,
-                        "label": "A (220.00 Hz)"
-                    },
-                    {
-                        "value": 233.08,
-                        "label": "A#/Bb (233.08 Hz)"
-                    },
-                    {
-                        "value": 246.94,
-                        "label": "B (246.94 Hz)"
-                    },
-                    {
-                        "value": 261.63,
-                        "label": "C (261.63 Hz)"
-                    },
-                    {
-                        "value": 277.18,
-                        "label": "C#/Db (277.18 Hz)"
-                    },
-                    {
-                        "value": 293.66,
-                        "label": "D (296.66 Hz)"
-                    },
-                    {
-                        "value": 311.13,
-                        "label": "D#/Eb (311.13 Hz)"
-                    },
-                    {
-                        "value": 329.63,
-                        "label": "E (329.63 Hz)"
-                    },
-                    {
-                        "value": 349.23,
-                        "label": "F (349.23 Hz)"
-                    },
-                    {
-                        "value": 369.99,
-                        "label": "F#/Gb (369.99 Hz)"
-                    },
-                    {
-                        "value": 392.00,
-                        "label": "G (392.00 Hz)"
-                    },
-                    {
-                        "value": 415.30,
-                        "label": "G#/Ab (415.30 Hz)"
-                    },
-                    {
-                        "value": 440.00,
-                        "label": "A (440.00 Hz)"
-                    }
-                ]
+    "label": "Tuning Note",
+    "class": "TuningNoteLink",
+    "options": [
+        {
+            "src": "freq",
+            "label": "Frequency",
+            "type": "number",
+            "defaultVal": 440,
+            "field": {
+                "type": "dropdown",
+                "fieldOptions": {
+                    "labels": [
+                        {
+                            "value": 174.61,
+                            "label": "F (174.61 Hz)"
+                        },
+                        {
+                            "value": 185.00,
+                            "label": "F#/Gb (185.00 Hz)"
+                        },
+                        {
+                            "value": 196.00,
+                            "label": "G (196.00 Hz)"
+                        },
+                        {
+                            "value": 207.65,
+                            "label": "G#/Ab (207.65 Hz)"
+                        },
+                        {
+                            "value": 220.00,
+                            "label": "A (220.00 Hz)"
+                        },
+                        {
+                            "value": 233.08,
+                            "label": "A#/Bb (233.08 Hz)"
+                        },
+                        {
+                            "value": 246.94,
+                            "label": "B (246.94 Hz)"
+                        },
+                        {
+                            "value": 261.63,
+                            "label": "C (261.63 Hz)"
+                        },
+                        {
+                            "value": 277.18,
+                            "label": "C#/Db (277.18 Hz)"
+                        },
+                        {
+                            "value": 293.66,
+                            "label": "D (296.66 Hz)"
+                        },
+                        {
+                            "value": 311.13,
+                            "label": "D#/Eb (311.13 Hz)"
+                        },
+                        {
+                            "value": 329.63,
+                            "label": "E (329.63 Hz)"
+                        },
+                        {
+                            "value": 349.23,
+                            "label": "F (349.23 Hz)"
+                        },
+                        {
+                            "value": 369.99,
+                            "label": "F#/Gb (369.99 Hz)"
+                        },
+                        {
+                            "value": 392.00,
+                            "label": "G (392.00 Hz)"
+                        },
+                        {
+                            "value": 415.30,
+                            "label": "G#/Ab (415.30 Hz)"
+                        },
+                        {
+                            "value": 440.00,
+                            "label": "A (440.00 Hz)"
+                        }
+                    ]
+                }
             }
-          }
-      },
-      {
-        "src": "vol",
-        "label": "Volume",
-        "type": "number",
-        "defaultVal": 0.5,
-        "field": {
-          "type": "slider",
-          "fieldOptions": {
-              "marks": [
-                  {
-                      "value": 1,
-                      "label": "Quieter"
-                  },
-                  {
-                      "value": 2,
-                      "label": "Louder"
-                  }
-              ],
-              "logarithmic": false,
-              "min": 0,
-              "max": 3,
-              "step": 0.01,
-              "scale": 1
-          }
+        },
+        {
+            "src": "vol",
+            "label": "Volume",
+            "type": "number",
+            "defaultVal": 0.5,
+            "field": {
+                "type": "slider",
+                "fieldOptions": {
+                    "marks": [
+                        {
+                            "value": 1,
+                            "label": "Quieter"
+                        },
+                        {
+                            "value": 2,
+                            "label": "Louder"
+                        }
+                    ],
+                    "logarithmic": false,
+                    "min": 0,
+                    "max": 3,
+                    "step": 0.01,
+                    "scale": 1
+                }
+            }
         }
-      }
-  ]
+    ]
 }

--- a/links/TuningNoteLink/config.json
+++ b/links/TuningNoteLink/config.json
@@ -8,26 +8,77 @@
           "type": "number",
           "defaultVal": 440,
           "field": {
-              "type": "slider",
-              "fieldOptions": {
-                  "marks": [
-                      {
-                          "value": 80,
-                          "label": "80hz"
-                      },
-                      {
-                          "value": 440,
-                          "label": "440hz"
-                      },
-                      {
-                        "value": 880,
-                        "label": "880hz"
-                      }
-                  ],
-                  "logarithmic": true,
-                  "min": 65,
-                  "max": 1050
-              }
+              "type": "dropdown",
+              "labels": [
+                  {
+                      "value": 174.61,
+                      "label": "F (174.61 Hz)"
+                  },
+                  {
+                      "value": 185.00,
+                      "label": "F#/Gb (185.00 Hz)"
+                  },
+                  {
+                      "value": 196.00,
+                      "label": "G (196.00 Hz)"
+                  },
+                  {
+                      "value": 207.65,
+                      "label": "G#/Ab (207.65 Hz)"
+                  },
+                  {
+                      "value": 220.00,
+                      "label": "A (220.00 Hz)"
+                  },
+                  {
+                      "value": 233.08,
+                      "label": "A#/Bb (233.08 Hz)"
+                  },
+                  {
+                      "value": 246.94,
+                      "label": "B (246.94 Hz)"
+                  },
+                  {
+                      "value": 261.63,
+                      "label": "C (261.63 Hz)"
+                  },
+                  {
+                      "value": 277.18,
+                      "label": "C#/Db (277.18 Hz)"
+                  },
+                  {
+                      "value": 293.66,
+                      "label": "D (296.66 Hz)"
+                  },
+                  {
+                      "value": 311.13,
+                      "label": "D#/Eb (311.13 Hz)"
+                  },
+                  {
+                      "value": 329.63,
+                      "label": "E (329.63 Hz)"
+                  },
+                  {
+                      "value": 349.23,
+                      "label": "F (349.23 Hz)"
+                  },
+                  {
+                      "value": 369.99,
+                      "label": "F#/Gb (369.99 Hz)"
+                  },
+                  {
+                      "value": 392.00,
+                      "label": "G (392.00 Hz)"
+                  },
+                  {
+                      "value": 415.30,
+                      "label": "G#/Ab (415.30 Hz)"
+                  },
+                  {
+                      "value": 440.00,
+                      "label": "A (440.00 Hz)"
+                  }
+              ]
           }
       },
       {

--- a/links/TuningNoteLink/config.json
+++ b/links/TuningNoteLink/config.json
@@ -9,76 +9,78 @@
           "defaultVal": 440,
           "field": {
               "type": "dropdown",
-              "labels": [
-                  {
-                      "value": 174.61,
-                      "label": "F (174.61 Hz)"
-                  },
-                  {
-                      "value": 185.00,
-                      "label": "F#/Gb (185.00 Hz)"
-                  },
-                  {
-                      "value": 196.00,
-                      "label": "G (196.00 Hz)"
-                  },
-                  {
-                      "value": 207.65,
-                      "label": "G#/Ab (207.65 Hz)"
-                  },
-                  {
-                      "value": 220.00,
-                      "label": "A (220.00 Hz)"
-                  },
-                  {
-                      "value": 233.08,
-                      "label": "A#/Bb (233.08 Hz)"
-                  },
-                  {
-                      "value": 246.94,
-                      "label": "B (246.94 Hz)"
-                  },
-                  {
-                      "value": 261.63,
-                      "label": "C (261.63 Hz)"
-                  },
-                  {
-                      "value": 277.18,
-                      "label": "C#/Db (277.18 Hz)"
-                  },
-                  {
-                      "value": 293.66,
-                      "label": "D (296.66 Hz)"
-                  },
-                  {
-                      "value": 311.13,
-                      "label": "D#/Eb (311.13 Hz)"
-                  },
-                  {
-                      "value": 329.63,
-                      "label": "E (329.63 Hz)"
-                  },
-                  {
-                      "value": 349.23,
-                      "label": "F (349.23 Hz)"
-                  },
-                  {
-                      "value": 369.99,
-                      "label": "F#/Gb (369.99 Hz)"
-                  },
-                  {
-                      "value": 392.00,
-                      "label": "G (392.00 Hz)"
-                  },
-                  {
-                      "value": 415.30,
-                      "label": "G#/Ab (415.30 Hz)"
-                  },
-                  {
-                      "value": 440.00,
-                      "label": "A (440.00 Hz)"
-                  }
-              ]
+              "fieldOptions": {
+                "labels": [
+                    {
+                        "value": 174.61,
+                        "label": "F (174.61 Hz)"
+                    },
+                    {
+                        "value": 185.00,
+                        "label": "F#/Gb (185.00 Hz)"
+                    },
+                    {
+                        "value": 196.00,
+                        "label": "G (196.00 Hz)"
+                    },
+                    {
+                        "value": 207.65,
+                        "label": "G#/Ab (207.65 Hz)"
+                    },
+                    {
+                        "value": 220.00,
+                        "label": "A (220.00 Hz)"
+                    },
+                    {
+                        "value": 233.08,
+                        "label": "A#/Bb (233.08 Hz)"
+                    },
+                    {
+                        "value": 246.94,
+                        "label": "B (246.94 Hz)"
+                    },
+                    {
+                        "value": 261.63,
+                        "label": "C (261.63 Hz)"
+                    },
+                    {
+                        "value": 277.18,
+                        "label": "C#/Db (277.18 Hz)"
+                    },
+                    {
+                        "value": 293.66,
+                        "label": "D (296.66 Hz)"
+                    },
+                    {
+                        "value": 311.13,
+                        "label": "D#/Eb (311.13 Hz)"
+                    },
+                    {
+                        "value": 329.63,
+                        "label": "E (329.63 Hz)"
+                    },
+                    {
+                        "value": 349.23,
+                        "label": "F (349.23 Hz)"
+                    },
+                    {
+                        "value": 369.99,
+                        "label": "F#/Gb (369.99 Hz)"
+                    },
+                    {
+                        "value": 392.00,
+                        "label": "G (392.00 Hz)"
+                    },
+                    {
+                        "value": 415.30,
+                        "label": "G#/Ab (415.30 Hz)"
+                    },
+                    {
+                        "value": 440.00,
+                        "label": "A (440.00 Hz)"
+                    }
+                ]
+            }
           }
       },
       {

--- a/links/TuningNoteLink/config.json
+++ b/links/TuningNoteLink/config.json
@@ -1,0 +1,60 @@
+{
+  "label": "Tuning Note",
+  "class": "TuningNoteLink",
+  "options": [
+      {
+          "src": "freq",
+          "label": "Frequency",
+          "type": "number",
+          "defaultVal": 440,
+          "field": {
+              "type": "slider",
+              "fieldOptions": {
+                  "marks": [
+                      {
+                          "value": 80,
+                          "label": "80hz"
+                      },
+                      {
+                          "value": 440,
+                          "label": "440hz"
+                      },
+                      {
+                        "value": 880,
+                        "label": "880hz"
+                      }
+                  ],
+                  "logarithmic": true,
+                  "min": 65,
+                  "max": 1050
+              }
+          }
+      },
+      {
+        "src": "vol",
+        "label": "Volume",
+        "type": "number",
+        "defaultVal": 0.5,
+        "field": {
+          "type": "slider",
+          "fieldOptions": {
+              "marks": [
+                  {
+                      "value": 1,
+                      "label": "Quieter"
+                  },
+                  {
+                      "value": 2,
+                      "label": "Louder"
+                  }
+              ],
+              "logarithmic": false,
+              "min": 0,
+              "max": 3,
+              "step": 0.01,
+              "scale": 1
+          }
+        }
+      }
+  ]
+}

--- a/links/TuningNoteLink/config.json
+++ b/links/TuningNoteLink/config.json
@@ -87,7 +87,7 @@
             "src": "vol",
             "label": "Volume",
             "type": "number",
-            "defaultVal": 0.5,
+            "defaultVal": 0.20,
             "field": {
                 "type": "slider",
                 "fieldOptions": {


### PR DESCRIPTION
Work in progress PR for a tuning note link and metronome link. These links work if they're on the Signal chains upon server start, but changing their settings in real time does not work. Furthermore, if the server has started and the link is on, removing these links and adding the link back does not change them.

For example, if the tuning note is a 220hz while the server is on, changing it to 260hz in real time doesn't work. Furthermore, if you remove the link and add it back (defaults to 440hz), it still continues playing at 220hz even though the mixing interface says 440hz.

Lastly, using both links simultaneously leads to weirdly unexpected behavior - such as simply the order in which they appear affects the tuning note frequency that is played. For example, this plays the correct tuning note frequency.
![Screen Shot 2022-03-18 at 4 34 42 PM](https://user-images.githubusercontent.com/26987971/159096978-c0f7fefc-e2f8-4d37-ab32-3f6f6435e5cd.png)

and this plays the incorrect tuning note frequency at 440hz, where the only difference is the order of the links.
![Screen Shot 2022-03-18 at 4 35 38 PM](https://user-images.githubusercontent.com/26987971/159097026-12575bdd-2593-4ec8-ba62-5b78462a978a.png)

Additionally, we probably want to spend more time on what these links will look like in the UI, since rounding errors make it difficult to select frequencies precisely on a log scale, plus note names might be helpful depending on what kind of ensemble is performing. In any case, this will require additional work in SuperCollider.