### PR TITLE
remove bypassFx

### DIFF
--- a/mixers/OutputBusMixer/config.json
+++ b/mixers/OutputBusMixer/config.json
@@ -27,29 +27,6 @@
                     "scale": 100
                 }
             }
-        },
-        {
-            "src": "bypassFx",
-            "label": "Bypass FX",
-            "type": "number",
-            "defaultVal": 0,
-            "field": {
-                "type": "dropdown",
-                "fieldOptions": {
-                    "labels": [
-                        {
-                            "value": 0,
-                            "label": "No",
-                            "var": 0
-                        },
-                        {
-                            "value": 1,
-                            "label": "Yes",
-                            "var": 1
-                        }
-                    ]
-                }
-            }
         }
     ]
 }

--- a/mixers/PersonalMixer/config.json
+++ b/mixers/PersonalMixer/config.json
@@ -53,29 +53,6 @@
                     "scale": 100
                 }
             }
-        },
-        {
-            "src": "bypassFx",
-            "label": "Bypass FX",
-            "type": "number",
-            "defaultVal": 0,
-            "field": {
-                "type": "dropdown",
-                "fieldOptions": {
-                    "labels": [
-                        {
-                            "value": 0,
-                            "label": "No",
-                            "var": 0
-                        },
-                        {
-                            "value": 1,
-                            "label": "Yes",
-                            "var": 1
-                        }
-                    ]
-                }
-            }
         }
     ]
 }

--- a/mixers/SelfVolumeMixer/config.json
+++ b/mixers/SelfVolumeMixer/config.json
@@ -53,29 +53,6 @@
                     "scale": 100
                 }
             }
-        },
-        {
-            "src": "bypassFx",
-            "label": "Bypass FX",
-            "type": "number",
-            "defaultVal": 0,
-            "field": {
-                "type": "dropdown",
-                "fieldOptions": {
-                    "labels": [
-                        {
-                            "value": 0,
-                            "label": "No",
-                            "var": 0
-                        },
-                        {
-                            "value": 1,
-                            "label": "Yes",
-                            "var": 1
-                        }
-                    ]
-                }
-            }
         }
     ]
 }

--- a/presets/CathedralPreset/config.json
+++ b/presets/CathedralPreset/config.json
@@ -13,10 +13,6 @@
             {
                 "name": "selfVolume",
                 "value": 0.5
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     },
@@ -27,10 +23,6 @@
             {
                 "name": "masterVolume",
                 "value": 1.5
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     }

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -13,10 +13,6 @@
             {
                 "name": "selfVolume",
                 "value": 0.6
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     },
@@ -27,10 +23,6 @@
             {
                 "name": "masterVolume",
                 "value": 1.5
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     }

--- a/presets/DryRoomPreset/config.json
+++ b/presets/DryRoomPreset/config.json
@@ -13,10 +13,6 @@
             {
                 "name": "selfVolume",
                 "value": 0.5
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     },
@@ -27,10 +23,6 @@
             {
                 "name": "masterVolume",
                 "value": 1.5
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     }

--- a/presets/EchoHallPreset/config.json
+++ b/presets/EchoHallPreset/config.json
@@ -13,10 +13,6 @@
             {
                 "name": "selfVolume",
                 "value": 0.7
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     },
@@ -27,10 +23,6 @@
             {
                 "name": "masterVolume",
                 "value": 1.5
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     }

--- a/presets/EtherealEchoPreset/config.json
+++ b/presets/EtherealEchoPreset/config.json
@@ -13,10 +13,6 @@
             {
                 "name": "selfVolume",
                 "value": 0.5
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     },
@@ -27,10 +23,6 @@
             {
                 "name": "masterVolume",
                 "value": 1.5
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     }

--- a/presets/LargeGroupPreset/config.json
+++ b/presets/LargeGroupPreset/config.json
@@ -9,10 +9,6 @@
             {
                 "name": "masterVolume",
                 "value": 1.5
-            },
-            {
-              "name": "bypassFx",
-              "value": 0
             }
         ]
     }

--- a/presets/MicTestPreset/config.json
+++ b/presets/MicTestPreset/config.json
@@ -13,10 +13,6 @@
             {
                 "name": "selfVolume",
                 "value": 3
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     }

--- a/presets/RawStereoPreset/config.json
+++ b/presets/RawStereoPreset/config.json
@@ -13,10 +13,6 @@
             {
                 "name": "selfVolume",
                 "value": 0
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     },
@@ -27,10 +23,6 @@
             {
                 "name": "masterVolume",
                 "value": 1
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     }

--- a/presets/RehearsalRoomPreset/config.json
+++ b/presets/RehearsalRoomPreset/config.json
@@ -13,10 +13,6 @@
             {
                 "name": "selfVolume",
                 "value": 0.2
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     },
@@ -27,10 +23,6 @@
             {
                 "name": "masterVolume",
                 "value": 1.5
-            },
-            {
-                "name": "bypassFx",
-                "value": 0
             }
         ]
     }


### PR DESCRIPTION
Removes `bypassFx` from `jacktrip-sc`. This doesn't actually change the SC logic, just the UI and presets. If a studio is currently set to have `bypassFx` be `true`, then I think the studio admin would need to perform some action for the change to take effect by generating a new mixing configuration.

(Perhaps that's a bit too disruptive and we might also want to change the SC logic as well.)