### PR TITLE
Added 'makeup gain' slider to compressor link

### DIFF
--- a/links/CompressorLink/CompressorLink.sc
+++ b/links/CompressorLink/CompressorLink.sc
@@ -30,7 +30,7 @@ CompressorLink : Link {
     var<> attack;
     var<> release;
     var<> ratio;
-	var<> makeup;
+    var<> makeup;
 
     *new { | thresh = -10, attack = 0.01, release = 0.02, ratio = 0.5, makeup = 0 |
 		^super.new().thresh_(thresh).attack_(attack).release_(release).ratio_(ratio).makeup_(makeup);
@@ -44,7 +44,7 @@ CompressorLink : Link {
             relaxTime:  \compressor_release.kr(release),        // time (in seconds) before compression is fully removed
             slopeBelow: 1,                                      // range if gate; otherwise, 1
             slopeAbove: \compressor_ratio.kr(ratio),            // ratio if compression; otherwise, 1
-			makeup:     \compressor_makeup.kr(makeup)           // gain in dB to simply increase volume
+            makeup:     \compressor_makeup.kr(makeup)           // gain in dB to simply increase volume
         );
         ^signal
     }

--- a/links/CompressorLink/config.json
+++ b/links/CompressorLink/config.json
@@ -165,21 +165,21 @@
                 "fieldOptions": {
                     "marks": [
                         {
-                            "value": 0,
-                            "label": "0dB"
+                            "value": 6,
+                            "label": "6dB"
                         },
                         {
                             "value": 12,
                             "label": "12dB"
                         },
                         {
-                            "value": 24,
-                            "label": "24dB"
+                            "value": 18,
+                            "label": "18dB"
                         }
                     ],
                     "logarithmic": false,
                     "min": 0,
-                    "max": 30,
+                    "max": 24,
                     "step": 0.100,
                     "scale": 10
                 }

--- a/links/CompressorLink/config.json
+++ b/links/CompressorLink/config.json
@@ -169,24 +169,12 @@
                             "label": "0dB"
                         },
                         {
-                            "value": 6,
-                            "label": "6dB"
-                        },
-                        {
                             "value": 12,
                             "label": "12dB"
                         },
                         {
-                            "value": 18,
-                            "label": "18dB"
-                        },
-                        {
                             "value": 24,
                             "label": "24dB"
-                        },
-                        {
-                            "value": 30,
-                            "label": "30dB"
                         }
                     ],
                     "logarithmic": false,

--- a/links/CompressorLink/config.json
+++ b/links/CompressorLink/config.json
@@ -154,6 +154,48 @@
                     ]
                 }
             }
-        }        
+        },
+        {
+            "src": "makeup",
+            "label": "Makeup Gain (dB)",
+            "type": "number",
+            "defaultVal": 0,
+            "field": {
+                "type": "slider",
+                "fieldOptions": {
+                    "marks": [
+                        {
+                            "value": 0,
+                            "label": "0dB"
+                        },
+                        {
+                            "value": 6,
+                            "label": "6dB"
+                        },
+                        {
+                            "value": 12,
+                            "label": "12dB"
+                        },
+                        {
+                            "value": 18,
+                            "label": "18dB"
+                        },
+                        {
+                            "value": 24,
+                            "label": "24dB"
+                        },
+                        {
+                            "value": 30,
+                            "label": "30dB"
+                        }
+                    ],
+                    "logarithmic": false,
+                    "min": 0,
+                    "max": 30,
+                    "step": 0.100,
+                    "scale": 10
+                }
+            }
+        }
     ]
 }

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -92,6 +92,10 @@
                 {
                     "name": "ratio",
                     "value": 0.667
+                },
+                {
+                    "name": "makeup",
+                    "value": 6
                 }
             ]
         },


### PR DESCRIPTION
Since audio compression makes loud parts of the signal quieter, a classic parameter of any compressor should be a gain slider to 'make up' for the volume that was compressed. So the overall amplitude is raised after compression. Also otherwise we'd be giving away valuable headroom.
The name makeup gain suggests that the gain happens after the compression and might be more clear than simply 'volume'. Also, some compressors have two volume parameters, one happening before and one happening after the non-linear effect. I think this simple solution is best for the average JackTrip user..  screenshot attached:
<img width="678" alt="Screenshot 2022-06-07 at 12 36 42" src="https://user-images.githubusercontent.com/51293620/172360903-7c335d46-f574-4103-add0-3181ae367b88.png">

