### PR TITLE
Fix/makeup gain

### DIFF
--- a/links/CompressorLink/CompressorLink.sc
+++ b/links/CompressorLink/CompressorLink.sc
@@ -44,7 +44,7 @@ CompressorLink : Link {
             relaxTime:  \compressor_release.kr(release),        // time (in seconds) before compression is fully removed
             slopeBelow: 1,                                      // range if gate; otherwise, 1
             slopeAbove: \compressor_ratio.kr(ratio),            // ratio if compression; otherwise, 1
-            makeup:     \compressor_makeup.kr(makeup)           // gain in dB to simply increase volume
+            mul:        \compressor_makeup.kr(makeup)           // multiplier to gain output volume
         );
         ^signal
     }

--- a/links/CompressorLink/config.json
+++ b/links/CompressorLink/config.json
@@ -165,23 +165,23 @@
                 "fieldOptions": {
                     "marks": [
                         {
-                            "value": 1.2,
-                            "label": "1.2"
-                        },
-                        {
                             "value": 1.5,
-                            "label": "1.5"
+                            "label": "+3dB"
                         },
                         {
-                            "value": 1.8,
-                            "label": "1.8"
+                            "value": 2,
+                            "label": "+6dB"
+                        },
+                        {
+                            "value": 9,
+                            "label": "+10dB"
                         }
                     ],
-                    "logarithmic": false,
+                    "logarithmic": true,
                     "min": 1,
-                    "max": 2,
-                    "step": 0.001,
-                    "scale": 1000
+                    "max": 10,
+                    "step": 0.01,
+                    "scale": 1
                 }
             }
         }

--- a/links/CompressorLink/config.json
+++ b/links/CompressorLink/config.json
@@ -165,16 +165,12 @@
                 "fieldOptions": {
                     "marks": [
                         {
-                            "value": 1.2,
-                            "label": "+1dB"
-                        },
-                        {
                             "value": 2,
                             "label": "+6dB"
                         },
                         {
-                            "value": 6,
-                            "label": "+8dB"
+                            "value": 5,
+                            "label": "+12dB"
                         }
                     ],
                     "logarithmic": true,

--- a/links/CompressorLink/config.json
+++ b/links/CompressorLink/config.json
@@ -165,19 +165,19 @@
                 "fieldOptions": {
                     "marks": [
                         {
-                            "value": 2,
-                            "label": "+6dB"
+                            "value": 0.5,
+                            "label": "Quieter"
                         },
                         {
-                            "value": 5,
-                            "label": "+12dB"
+                            "value": 2.5,
+                            "label": "Louder"
                         }
                     ],
                     "logarithmic": false,
-                    "min": 1,
-                    "max": 10,
-                    "step": 0.01,
-                    "scale": 1
+                    "min": 0,
+                    "max": 3,
+                    "step": 0.05,
+                    "scale": 100
                 }
             }
         }

--- a/links/CompressorLink/config.json
+++ b/links/CompressorLink/config.json
@@ -157,31 +157,31 @@
         },
         {
             "src": "makeup",
-            "label": "Makeup Gain (dB)",
+            "label": "Output volume",
             "type": "number",
-            "defaultVal": 0,
+            "defaultVal": 1,
             "field": {
                 "type": "slider",
                 "fieldOptions": {
                     "marks": [
                         {
-                            "value": 6,
-                            "label": "6dB"
+                            "value": 1.2,
+                            "label": "1.2"
                         },
                         {
-                            "value": 12,
-                            "label": "12dB"
+                            "value": 1.5,
+                            "label": "1.5"
                         },
                         {
-                            "value": 18,
-                            "label": "18dB"
+                            "value": 1.8,
+                            "label": "1.8"
                         }
                     ],
                     "logarithmic": false,
-                    "min": 0,
-                    "max": 24,
-                    "step": 0.100,
-                    "scale": 10
+                    "min": 1,
+                    "max": 2,
+                    "step": 0.001,
+                    "scale": 1000
                 }
             }
         }

--- a/links/CompressorLink/config.json
+++ b/links/CompressorLink/config.json
@@ -173,7 +173,7 @@
                             "label": "+12dB"
                         }
                     ],
-                    "logarithmic": true,
+                    "logarithmic": false,
                     "min": 1,
                     "max": 10,
                     "step": 0.01,

--- a/links/CompressorLink/config.json
+++ b/links/CompressorLink/config.json
@@ -165,16 +165,16 @@
                 "fieldOptions": {
                     "marks": [
                         {
-                            "value": 1.5,
-                            "label": "+3dB"
+                            "value": 1.2,
+                            "label": "+1dB"
                         },
                         {
                             "value": 2,
                             "label": "+6dB"
                         },
                         {
-                            "value": 9,
-                            "label": "+10dB"
+                            "value": 6,
+                            "label": "+8dB"
                         }
                     ],
                     "logarithmic": true,


### PR DESCRIPTION
Fixed a bug where the Compressor's Output Volume (Makeup gain) didn't work. The reason was that the Compander function needed a param called `mul` instead of `makeup`.

An additional change was that I've adjusted the Output Volume slider to look and behave like the volume link slider. That makes our SoundScapes design more coherent.

![Screenshot 2022-09-09 at 10 16 26](https://user-images.githubusercontent.com/51293620/189304720-b6fe4fce-ea96-4a4d-bfbf-014d44446c99.png)
