### PR TITLE
Rename default-mono to default-mix

### DIFF
--- a/presets/DefaultMonoInputsPreset/config.json
+++ b/presets/DefaultMonoInputsPreset/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "default-mono",
+    "id": "default-mix",
     "label": "Default (Mono inputs)",
     "tooltip": "A true all-rounder. (Mono inputs)",
     "mixer": "SelfVolumeMixer",


### PR DESCRIPTION
Parts of our interface rely on the preset selected to have the id "default-mix". I guess we're messing up the semantics here, but it would be ideal to not have to change all the places where the web looks for this.