### PR TITLE
Stereo Imaging Distortion bugfix (SoundScapes Compressor and Limiter link)

### DIFF
--- a/links/CompressorLink/CompressorLink.sc
+++ b/links/CompressorLink/CompressorLink.sc
@@ -38,7 +38,8 @@ CompressorLink : Link {
 
     ar { | input, id = "" |
         var signal = input;
-        signal = Compander.ar(signal, signal,
+		var monomix = Mix(input); // Mix signal to mono, preventing stereo imaging distortion (same compression for both channels)
+        signal = Compander.ar(signal, monomix,
             thresh:     \compressor_thresh.kr(thresh).dbamp,    // amplitude trigger threshold [-1, 1]
             clampTime:  \compressor_attack.kr(attack),          // time (in seconds) before full compression ratio is applied
             relaxTime:  \compressor_release.kr(release),        // time (in seconds) before compression is fully removed

--- a/links/LimiterLink/LimiterLink.sc
+++ b/links/LimiterLink/LimiterLink.sc
@@ -35,7 +35,7 @@ LimiterLink : Link {
 
     ar { | input, id = "" |
         var signal = input;
-		var monomix = Mix(input);
+		var monomix = Mix(input); // Mix signal to mono, preventing stereo imaging distortion (same compression for both channels)
         signal = Compander.ar(signal, monomix,
             thresh:     \limiter_thresh.kr(thresh).dbamp,   // amplitude trigger threshold [-1, 1]
             clampTime:  \limiter_attack.kr(attack),         // time (in seconds) before compression is applied

--- a/links/LimiterLink/LimiterLink.sc
+++ b/links/LimiterLink/LimiterLink.sc
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2021 JackTrip Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/* 
+/*
  * LimiterLink: prevents audio output from exceeding a specified volume threshold.
  *
  * \thresh: amplitude trigger threshold, in decibels (< 0)
@@ -35,7 +35,8 @@ LimiterLink : Link {
 
     ar { | input, id = "" |
         var signal = input;
-        signal = Compander.ar(signal, signal,
+		var monomix = Mix(input);
+        signal = Compander.ar(signal, monomix,
             thresh:     \limiter_thresh.kr(thresh).dbamp,   // amplitude trigger threshold [-1, 1]
             clampTime:  \limiter_attack.kr(attack),         // time (in seconds) before compression is applied
             relaxTime:  \limiter_release.kr(release),       // time (in seconds) before compression is removed


### PR DESCRIPTION
### What was the problem?
When a compressor or limiter link worked hard (i.e. affected the signal with lots of gain reduction), the stereo sound image got audibly distorted: It seemed like the instruments/the whole mix mix quickly jumped from left to right and vice versa. An audible example was reported by @mikedickey in [this](url) Radio recording.
 
### Assumption of problem origin
The compressor and limiter were compressing stereo channels independently. E.g., if a guitar plays a sound that is panned 80% to the left side, the compressor might only compress channel 1 (the left side of that signal), since channel 2 (the right side of the signal) might not even get louder than the compression threshold. This resulted in the guitar's phantom sound source jumping towards the center of the stereo image, as both channels will be relatively closer to each other in volume.
 
### Implementation of solution (screenshot below)
The [compander.ar() function](url) uses two inputs, one being the actual signal (stereo array) and one being the detection signal (sometimes called side-chain signal).
_(Generally it's cool that we can choose a different signal for loudness detection, as that might allow us to have certain instruments react dynamically to other signals in the long run, allowing for more advanced mixing.)_
Anyways, I've used SuperCollider's [Mix() function](url) to sum our detection signal to mono and have our actual stereo signal duck depending on that mono sum. This means that we take into consideration the loudness of both left&right channels (not just one of them), while we let the compressor and limiter apply its gain reduction equally to both channels in our actual signal.
 
### My test results
I've tested this with stereo signals, and I've tested on both Input and Output chain. Works seemlessly for me now, but I'd appreciate your review.


**Before:**
![Screenshot 2022-10-06 at 16 45 43](https://user-images.githubusercontent.com/51293620/194344114-a375fa18-686a-45c0-8062-05997721fbcf.png)

**After:**
<img width="1021" alt="Screenshot 2022-10-06 at 14 01 10" src="https://user-images.githubusercontent.com/51293620/194342595-8cd09e07-c83e-4be1-9434-7c3dd48d1e75.png">


