### PR TITLE
Fixing aggressive noise gate in 'Small Choir' preset.

### DIFF
--- a/presets/SmallChoirPreset/config.json
+++ b/presets/SmallChoirPreset/config.json
@@ -56,7 +56,7 @@
                 },
                 {
                     "name": "range",
-                    "value": 6
+                    "value": 1.6
                 }
             ]
         }


### PR DESCRIPTION
@mikedickey correctly pointed out that the noise gate for the Small Choir was quite aggressive. The reason was the range parameter, which I tamed quite a bit. Should be better now.