### PR TITLE
Replacing Circle Pan Link with regular Pan link in presets

### DIFF
--- a/presets/BandPreset/config.json
+++ b/presets/BandPreset/config.json
@@ -21,7 +21,7 @@
     ],
     "preChain": [
         {
-            "name": "CirclePanLink",
+            "name": "PanningLink",
             "options": [
                 {
                     "name": "panSlots",

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -21,7 +21,7 @@
     ],
     "preChain": [
         {
-            "name": "CirclePanLink",
+            "name": "PanningLink",
             "options": [
                 {
                     "name": "panSlots",

--- a/presets/EnsemblePreset/config.json
+++ b/presets/EnsemblePreset/config.json
@@ -21,7 +21,7 @@
     ],
     "preChain": [
         {
-            "name": "CirclePanLink",
+            "name": "PanningLink",
             "options": [
                 {
                     "name": "panSlots",

--- a/presets/MeetingRoomPreset/config.json
+++ b/presets/MeetingRoomPreset/config.json
@@ -21,7 +21,7 @@
     ],
     "preChain": [
         {
-            "name": "CirclePanLink",
+            "name": "PanningLink",
             "options": [
                 {
                     "name": "panSlots",

--- a/presets/MusicClassPreset/config.json
+++ b/presets/MusicClassPreset/config.json
@@ -21,7 +21,7 @@
     ],
     "preChain": [
         {
-            "name": "CirclePanLink",
+            "name": "PanningLink",
             "options": [
                 {
                     "name": "panSlots",

--- a/presets/SmallChoirPreset/config.json
+++ b/presets/SmallChoirPreset/config.json
@@ -21,7 +21,7 @@
     ],
     "preChain": [
         {
-            "name": "CirclePanLink",
+            "name": "PanningLink",
             "options": [
                 {
                     "name": "panSlots",


### PR DESCRIPTION
Circle Pan uses Ambisonics Toolkit, which seems to be insanely slow and possibly not yet ready for real-time DSP