### PR TITLE
Hash signal chain link names when generating a synthdef name

### DIFF
--- a/links/SignalChain.sc
+++ b/links/SignalChain.sc
@@ -69,14 +69,32 @@ SignalChain : Class {
     getName {
         var name = "";
         
-        if (links.size == 0, { ^name; }, { name = "-"; });
-
         links.size.do({ |n|
             name = name ++ links[n].getName();
             if (n+1 < links.size, { name = name ++ "_"; });
         });
 
         ^name;
+    }
+
+    // returns a unique synth name for this signal chain
+    // note that we hash the name, since SC is limited to 128 bytes
+    getSynthName {
+        // djb2 hash algo from http://www.cse.yorku.ca/~oz/hash.html
+        var str = this.getName.value;
+        var hash = 5381;
+        var i = 0;
+        var c;
+
+        if (links.size == 0, { ^""; });
+
+        while ( { i < str.size }, {
+            c = str.at(i);
+            i = i + 1;
+            hash = ((hash << 5) + hash) + c.asInteger;
+        });
+
+        ^"-"++hash.asHexString;
     }
 
     // returns a list of synth arguments used by this signal chain

--- a/mixers/InputBusMixer.sc
+++ b/mixers/InputBusMixer.sc
@@ -71,7 +71,7 @@ InputBusMixer : BaseMixer {
         var node, g, b, args;
         var jacktripSynthName = "JackTripToInputBus";
         var jamulusSynthName = "JamulusToInputBus";
-        var preChainName;
+        var preChainName, preChainSynthName;
 
         // wait for server to be ready
         serverReady.wait;
@@ -79,8 +79,10 @@ InputBusMixer : BaseMixer {
         // execute preChain before actions
         if(bypassFx==1, {
             preChainName = "";
+            preChainSynthName = "";
         }, {
             preChainName = preChain.getName();
+            preChainSynthName = preChain.getSynthName();
             preChain.before(server);
         });
 
@@ -106,9 +108,9 @@ InputBusMixer : BaseMixer {
         // create a bundle of commands to execute
         b = server.makeBundle(nil, {
             // create synthdef to send audio to the input busses
-            this.sendSynthDef(jacktripSynthName, jacktripSynthName ++ preChainName);
+            this.sendSynthDef(jacktripSynthName, jacktripSynthName ++ preChainSynthName);
             if (withJamulus, {
-                this.sendSynthDef(jamulusSynthName, jamulusSynthName ++ preChainName);
+                this.sendSynthDef(jamulusSynthName, jamulusSynthName ++ preChainSynthName);
             });
             
             // free any existing nodes
@@ -130,26 +132,26 @@ InputBusMixer : BaseMixer {
         if(bypassFx==1, {
             // create dry jacktrip synth
             node = Synth(jacktripSynthName, args, g, \addToTail);
-            ("Created synth" + (jacktripSynthName ++ preChainName) + node.nodeID).postln;
+            ("Created synth" + (jacktripSynthName ++ preChainSynthName) + preChainName + node.nodeID).postln;
 
             if (withJamulus, {
                 // create dry jamulus synth
                 args = args ++ [\delay, jamulusDelay];
                 node = Synth(jamulusSynthName, args, g, \addToTail);
-                ("Created synth" + (jamulusSynthName ++ preChainName) + node.nodeID).postln;
+                ("Created synth" + (jamulusSynthName ++ preChainSynthName) + preChainName + node.nodeID).postln;
             });
         }, {
             // create jacktrip synth with effects
             args = args ++ preChain.getArgs();
-            node = Synth(jacktripSynthName ++ preChainName, args, g, \addToTail);
-            ("Created synth" + (jacktripSynthName ++ preChainName) + node.nodeID).postln;
+            node = Synth(jacktripSynthName ++ preChainSynthName, args, g, \addToTail);
+            ("Created synth" + (jacktripSynthName ++ preChainSynthName) + preChainName + node.nodeID).postln;
     
             if (withJamulus, {
                 // always default pan Jamulus to center if using PanningLink
                 args = args ++ [\delay, jamulusDelay];
                 // create jamulus synth with effects
-                node = Synth(jamulusSynthName ++ preChainName, args, g, \addToTail);
-                ("Created synth" + (jamulusSynthName ++ preChainName) + node.nodeID).postln;
+                node = Synth(jamulusSynthName ++ preChainSynthName, args, g, \addToTail);
+                ("Created synth" + (jamulusSynthName ++ preChainSynthName) + preChainName + node.nodeID).postln;
             });
 
             // execute preChain after actions

--- a/mixers/OutputBusMixer/OutputBusMixer.sc
+++ b/mixers/OutputBusMixer/OutputBusMixer.sc
@@ -36,7 +36,7 @@ OutputBusMixer : InputBusMixer {
     start {
         var b, g, node, args;
         var synthName = "JackTripDownMixOut";
-        var postChainName;
+        var postChainName, postChainSynthName;
 
         // use alternate synth if broadcast is true
         if (broadcast, {
@@ -49,8 +49,10 @@ OutputBusMixer : InputBusMixer {
         // execute postChain before actions
         if(bypassFx==1, {
             postChainName = "";
+            postChainSynthName = "";
         }, {
             postChainName = postChain.getName();
+            postChainSynthName = postChain.getSynthName();
             postChain.before(server);
         });
 
@@ -59,7 +61,7 @@ OutputBusMixer : InputBusMixer {
 
         // create a bundle of commands to execute
         b = server.makeBundle(nil, {
-            this.sendSynthDef(synthName, synthName ++ postChainName);
+            this.sendSynthDef(synthName, synthName ++ postChainSynthName);
 
             // use group 100 for client input synths and use group 200 for client output synths
             // p_new is a server command (see Server Command Reference on SC documentation)
@@ -75,11 +77,11 @@ OutputBusMixer : InputBusMixer {
         if(bypassFx==1, {
             node = Synth(synthName, nil, g, \addToTail);
         }, {
-            node = Synth(synthName ++ postChainName, postChain.getArgs(), g, \addToTail);
+            node = Synth(synthName ++ postChainSynthName, postChain.getArgs(), g, \addToTail);
             // execute postChain after actions
             postChain.after(server, node);
         });
-        ("Created synth" + (synthName ++ postChainName) + node.nodeID).postln;
+        ("Created synth" + (synthName ++ postChainSynthName) + postChainName + node.nodeID).postln;
 
         // signal that the mix has started
         // signal is defined in the BaseMix class and represents a Condition object

--- a/mixers/PersonalMixer/PersonalMixer.sc
+++ b/mixers/PersonalMixer/PersonalMixer.sc
@@ -48,7 +48,7 @@ PersonalMixer : InputBusMixer {
     start {
         var b, g, p, node, args, personalMixes;
         var synthName = "JackTripPersonalMixOut";
-        var postChainName;
+        var postChainName, postChainSynthName;
 
         // start input bus mixer first
         super.start();
@@ -56,8 +56,10 @@ PersonalMixer : InputBusMixer {
         // execute postChain before actions
         if(bypassFx==1, {
             postChainName = "";
+            postChainSynthName = "";
         }, {
             postChainName = postChain.getName();
+            postChainSynthName = postChain.getSynthName();
             postChain.before(server);
         });
 
@@ -66,7 +68,7 @@ PersonalMixer : InputBusMixer {
 
         // create a bundle of commands to execute
         b = server.makeBundle(nil, {
-            this.sendSynthDef(synthName, synthName ++ postChainName);
+            this.sendSynthDef(synthName, synthName ++ postChainSynthName);
 
             // use group 100 for client input synths and use group 200 for client output synths
             // p_new is a server command (see Server Command Reference on SC documentation)
@@ -99,11 +101,11 @@ PersonalMixer : InputBusMixer {
             node = Synth(synthName, args, g, \addToTail);
         }, {
             args = [\mix, personalMixes] ++ postChain.getArgs();
-            node = Synth(synthName ++ postChainName, args, g, \addToTail);
+            node = Synth(synthName ++ postChainSynthName, args, g, \addToTail);
             // execute postChain after actions
             postChain.after(server, node);
         });
-        ("Created synth" + (synthName ++ postChainName) + node.nodeID).postln;
+        ("Created synth" + (synthName ++ postChainSynthName) + postChainName + node.nodeID).postln;
 
         // signal that the mix has started
         // signal is defined in the BaseMix class and represents a Condition object

--- a/mixers/SelfVolumeMixer/SelfVolumeMixer.sc
+++ b/mixers/SelfVolumeMixer/SelfVolumeMixer.sc
@@ -49,7 +49,7 @@ SelfVolumeMixer : InputBusMixer {
         var b, g, p, node;
         var jacktripSynthName = "JackTripSelfVolumeMixOut";
         var jamulusSynthName = "JamulusDownMixOut";
-        var postChainName;
+        var postChainName, postChainSynthName;
 
         // start input bus mixer first
         super.start();
@@ -57,8 +57,10 @@ SelfVolumeMixer : InputBusMixer {
         // execute postChain before actions
         if(bypassFx==1, {
             postChainName = "";
+            postChainSynthName = "";
         }, {
             postChainName = postChain.getName();
+            postChainSynthName = postChain.getSynthName();
             postChain.before(server);
         });
 
@@ -67,9 +69,9 @@ SelfVolumeMixer : InputBusMixer {
 
         // create a bundle of commands to execute
         b = server.makeBundle(nil, {
-            this.sendSynthDef(jacktripSynthName, jacktripSynthName ++ postChainName);
+            this.sendSynthDef(jacktripSynthName, jacktripSynthName ++ postChainSynthName);
             if (withJamulus, {
-                this.sendSynthDef(jamulusSynthName, jamulusSynthName ++ postChainName);
+                this.sendSynthDef(jamulusSynthName, jamulusSynthName ++ postChainSynthName);
             });
 
             // use group 100 for client input synths and use group 200 for client output synths
@@ -111,9 +113,9 @@ SelfVolumeMixer : InputBusMixer {
                 node = Synth(synthName, args, g, \addToTail);
             }, {
                 args = args ++ postChain.getArgs();
-                node = Synth(synthName ++ postChainName, args, g, \addToTail);
+                node = Synth(synthName ++ postChainSynthName, args, g, \addToTail);
             });
-            ("Created synth" + (synthName ++ postChainName) + node.nodeID).postln;
+            ("Created synth" + (synthName ++ postChainSynthName) + postChainName + node.nodeID).postln;
         };
 
         // execute postChain after actions


### PR DESCRIPTION
We were previously concatenating all the names of links together to generate unique synth names. Unfortuantely, if you have a long enough chain of links, you can end up with names longer than 128 bytes, which seems to be the max size allowed by supercollider.

This causes it to crash in really ugly loops that can only be recovered from by manually clearing out all the synthdef caches and restarting.