### PR TITLE
Adding OSC endpoints for controlling synth parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,21 @@ For example, to start a simple mixer on your local SuperCollider server for
 two clients, run:
 
 ```
-SimpleMix(2).connect.start;
+~maxClients = 1;
+
+~mixer = SimpleMixer(~maxClients).withJamulus_(false);
+
+Routine {
+    ~mixer.connect.start.wait;
+}.run;
 ```
 
 To start a simple mixer on a remote audio server with IP address 10.20.1.10:
 
 ```
-SimpleMix(2).serverIp_("10.20.1.10").connect.start;
+Routine {
+    SimpleMixer(2).serverIp_("10.20.1.10").connect.start;
+}.run
 ```
 
 Note that you can use `serverIp` to connect to and run mixers on remote

--- a/mixers/BaseMixer.sc
+++ b/mixers/BaseMixer.sc
@@ -152,4 +152,18 @@ BaseMixer : Object {
             }).play(server, [\buffer, b]);
         }, oscPath);
     }
+
+    // add OSC listeners for each synth control available
+    addOSCControls { | oscpath, synthName, node |
+        SynthDescLib.global.match(synthName).controlNames.do({ |c|
+            var path = "/" ++ oscpath ++ "/" ++ c;
+            OSCFunc({ |args|
+                if (args.size == 2, {
+                    (oscpath ++ ": setting" + c + "to" + args[1]).postln;
+                    node.set(c, args[1]);
+                });
+            }, path);
+            ("Added OSC endpoint for" + path).postln;
+        });
+    }
 }

--- a/mixers/InputBusMixer.sc
+++ b/mixers/InputBusMixer.sc
@@ -68,12 +68,12 @@ InputBusMixer : BaseMixer {
 
     // starts up JackTripToInputBus synth (must be run from a Routine)
     start {
-        var node, g, b, args;
+        var g, b, args;
         var jacktripSynthName = "JackTripToInputBus";
         var jamulusSynthName = "JamulusToInputBus";
         var speakerSynthName = "SpeakerToInputBus";
         var preChainName, preChainSynthName;
-        var jackTripNode, jamulusNode;
+        var speakerNode, jackTripNode, jamulusNode;
 
         // wait for server to be ready
         serverReady.wait;
@@ -134,8 +134,8 @@ InputBusMixer : BaseMixer {
         args = [\mix, defaultMix, \mul, masterVolume];
 
         // create dry speaker synth
-        node = Synth(speakerSynthName, args, g, \addToTail);
-        ("Created synth" + speakerSynthName + node.nodeID).postln;
+        speakerNode = Synth(speakerSynthName, args, g, \addToTail);
+        ("Created synth" + speakerSynthName + speakerNode.nodeID).postln;
 
         if(bypassFx==1, {
             // create dry jacktrip synth
@@ -163,10 +163,16 @@ InputBusMixer : BaseMixer {
             });
 
             // execute preChain after actions
-            preChain.after(server, node);
+            preChain.after(server, speakerNode);
         });
 
         // add osc paths for the mixer
+        OSCFunc({ |args|
+            if (args.size == 3, {
+                ("speaker: setting" + args[1] + "to" + args[2]).postln;
+                speakerNode.set(args[1], args[2]);
+            });
+        }, "/speaker");
         OSCFunc({ |args|
             if (args.size == 3, {
                 ("input: setting" + args[1] + "to" + args[2]).postln;

--- a/mixers/OutputBusMixer/OutputBusMixer.sc
+++ b/mixers/OutputBusMixer/OutputBusMixer.sc
@@ -85,6 +85,14 @@ OutputBusMixer : InputBusMixer {
         });
         ("Created synth" + (synthName ++ postChainSynthName) + postChainName + node.nodeID).postln;
 
+        // add osc paths for the mixer
+        OSCFunc({ |args|
+            if (args.size == 3, {
+                ("output: setting" + args[1] + "to" + args[2]).postln;
+                node.set(args[1], args[2]);
+            });
+        }, "/output");
+
         // signal that the mix has started
         // signal is defined in the BaseMix class and represents a Condition object
         // after these two lines are executed, the BaseMix knows that the

--- a/mixers/SelfVolumeMixer/SelfVolumeMixer.sc
+++ b/mixers/SelfVolumeMixer/SelfVolumeMixer.sc
@@ -47,6 +47,7 @@ SelfVolumeMixer : InputBusMixer {
     // starts up all the audio on the server
     start {
         var b, g, p, node;
+        var nodes = [];
         var jacktripSynthName = "JackTripSelfVolumeMixOut";
         var jamulusSynthName = "JamulusDownMixOut";
         var postChainName, postChainSynthName;
@@ -116,10 +117,25 @@ SelfVolumeMixer : InputBusMixer {
                 node = Synth(synthName ++ postChainSynthName, args, g, \addToTail);
             });
             ("Created synth" + (synthName ++ postChainSynthName) + postChainName + node.nodeID).postln;
+
+            // execute postChain after actions
+            postChain.after(server, node);
+            nodes = nodes.add(node);
         };
 
-        // execute postChain after actions
-        postChain.after(server, node);
+        // add osc paths for the mixer
+        OSCFunc({ |args|
+            if (args.size == 3, {
+                ("output: setting" + args[1] + "to" + args[2]).postln;
+                g.set(args[1], args[2]);
+            });
+        }, "/output");
+        OSCFunc({ |args|
+            if ((args.size == 4) && (args[1] < maxClients), {
+                ("clients[" ++ args[1] ++ "]: setting" + args[2] + "to" + args[3]).postln;
+                nodes[args[1]].set(args[2], args[3]);
+            });
+        }, "/clients");
 
         // signal that the mix has started
         // signal is defined in the BaseMix class and represents a Condition object

--- a/mixers/SimpleMixer/SimpleMixer.sc
+++ b/mixers/SimpleMixer/SimpleMixer.sc
@@ -59,6 +59,14 @@ SimpleMixer : BaseMixer {
         node = Synth("JackTripSimpleMix", [\mix, defaultMix, \mul, masterVolume], g, \addToTail);
         ("Created synth JackTripSimpleMix" + node.nodeID).postln;
 
+        // add osc paths for the mixer
+        OSCFunc({ |args|
+            if (args.size == 3, {
+                ("input: setting" + args[1] + "to" + args[2]).postln;
+                node.set(args[1], args[2]);
+            });
+        }, "/input");
+
         // signal that the mix has started
         this.mixStarted.test = true;
         this.mixStarted.signal;

--- a/synthdefs/BroadcastMixOut.scd
+++ b/synthdefs/BroadcastMixOut.scd
@@ -32,8 +32,7 @@
 
     speakerSignal = MulAdd(speakerSignal, \mul.kr(1.0), 0);
     speakerSignal = DelayN.ar(speakerSignal, 1.0, \speakerDelay.kr(0));
-    signal = speakerSignal ++ signal;
-    signal = AggregateLink().ar(signal);
+    signal = Mix([signal, speakerSignal]);
 
     Out.ar(0, signal);
 };

--- a/synthdefs/JackTripDownMixOut.scd
+++ b/synthdefs/JackTripDownMixOut.scd
@@ -34,8 +34,7 @@
 
     speakerSignal = MulAdd(speakerSignal, \mul.kr(1.0), 0);
     speakerSignal = DelayN.ar(speakerSignal, 1.0, \speakerDelay.kr(0));
-    signal = speakerSignal ++ signal;
-    signal = AggregateLink().ar(signal);
+    signal = Mix([signal, speakerSignal]);
 
     if (withJamulus, {
         // remove dry jamulus signal from the result to offset

--- a/synthdefs/JackTripPersonalMixOut.scd
+++ b/synthdefs/JackTripPersonalMixOut.scd
@@ -46,8 +46,7 @@
 
         speakerSignal = MulAdd(speakerSignal, personalMixes[(clientNum + 1) * maxClients - 1] * \mul.kr(1), 0);
         speakerSignal = DelayN.ar(speakerSignal, 1.0, \speakerDelay.kr(0));
-        signal = speakerSignal ++ signal;
-        signal = AggregateLink().ar(signal);
+        signal = Mix([signal, speakerSignal]);
         
         Out.ar(outputChannelsPerClient * clientNum, signal);
     });

--- a/synthdefs/JackTripSelfVolumeMixOut.scd
+++ b/synthdefs/JackTripSelfVolumeMixOut.scd
@@ -39,8 +39,7 @@
 
     speakerSignal = MulAdd(speakerSignal, \mul.kr(1.0), 0);
     speakerSignal = DelayN.ar(speakerSignal, 1.0, \speakerDelay.kr(0));
-    signal = speakerSignal ++ signal;
-    signal = AggregateLink().ar(signal);
+    signal = Mix([signal, speakerSignal]);
 
     Out.ar(\out.ir(0), signal);
 };

--- a/synthdefs/JamulusDownMixOut.scd
+++ b/synthdefs/JamulusDownMixOut.scd
@@ -33,8 +33,7 @@
 
     speakerSignal = MulAdd(speakerSignal, \mul.kr(1.0), 0);
     speakerSignal = DelayN.ar(speakerSignal, 1.0, \speakerDelay.kr(0));
-    signal = speakerSignal ++ signal;
-    signal = AggregateLink().ar(signal);
+    signal = Mix([signal, speakerSignal]);
 
     // remove dry jamulus signal from the result to offset
     // the fact that jamulus will be echoing back to all users already

--- a/synthdefs/JamulusToInputBus.scd
+++ b/synthdefs/JamulusToInputBus.scd
@@ -29,7 +29,7 @@
 
     // get raw jamulus signal, and add delay if necessary (for broadcast)
     drySignal = JackTripInput(1, inputChannelsPerClient).getSignal();
-    drySignal = DelayN.ar(drySignal, 1.0, \delay.kr(0));
+    drySignal = DelayN.ar(drySignal, 1.0, \jamulusDelay.kr(0));
 
     // generate wet signal by applying effects, and send to master input bus
     wetSignal = preChain.ar(drySignal);

--- a/synthdefs/SpeakerToInputBus.scd
+++ b/synthdefs/SpeakerToInputBus.scd
@@ -26,6 +26,10 @@
     var defaultMix = 1 ! maxClients;
     var levels = \mix.kr(defaultMix) * \mul.kr(1.0);
     var signal = JackTripInput(1, inputChannelsPerClient, true, (maxClients - 1) * inputChannelsPerClient).getSignal();
+    var metronome = MetronomeLink.new.vol_(0);
+    var tuningNote = TuningNoteLink.new.vol_(0);
+    signal = metronome.ar(signal);
+    signal = tuningNote.ar(signal);
     signal = MulAdd(signal[0], levels[maxClients - 1], 0);
     Out.ar(~inputBuses[maxClients - 1].index, signal);
 }


### PR DESCRIPTION
Adding OSC endpoints for controlling synth parameters

* `/input` for input chains
* `/speaker` for speaker channels
* `/output` for output chains
* `/clients` for individual client mix synths

Adding Metronome and TuningLink controls in speaker synth, controls also available via OSC

Fix for speaker channel breaking stereo signals