### PR TITLE
Removing PanningLink from default preset

### DIFF
--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -21,25 +21,6 @@
     ],
     "preChain": [
         {
-            "name": "PanningLink",
-            "options": [
-                {
-                    "name": "panSlots",
-                    "value": 10
-                },
-                {
-                    "names": [
-                        "left",
-                        "right"
-                    ],
-                    "values": [
-                        -0.3,
-                        0.3
-                    ]
-                }
-            ]
-        },
-        {
             "name": "GateLink",
             "options": [
                 {


### PR DESCRIPTION
This is no longer required now that we have "Mix to mono" and automatically copy left to right (via Jack connections) when only a single channel is sent.

It doesn't require people who want to send stereo mixes to change their soundscapes presets to make it sound good, and makes it easier to mix and match across a group.

Other presets, and of course custom presets are always availabe for anyone who wants auto panning. And no existing studio configurations will be changed unless they do it explicitly.