### PR TITLE
Update master volume levels for presets to 1.0

### DIFF
--- a/presets/BandPreset/config.json
+++ b/presets/BandPreset/config.json
@@ -10,7 +10,7 @@
             "options": [
                 {
                     "name": "masterVolume",
-                    "value": 1.5
+                    "value": 1.0
                 },
                 {
                     "name": "selfVolume",

--- a/presets/DefaultPreset/config.json
+++ b/presets/DefaultPreset/config.json
@@ -1,16 +1,16 @@
 {
     "id": "default",
     "label": "Default",
-    "tooltip": "A true all-rounder. (If all participants are sending stereo signals, try removing the Circular Pan link)",
+    "tooltip": "A true all-rounder.",
     "mixer": "SelfVolumeMixer",
     "mixerConfigs": [
         {
             "name": "SelfVolumeMixer",
-            "max": 10,
+            "max": 30,
             "options": [
                 {
                     "name": "masterVolume",
-                    "value": 1.5
+                    "value": 1.0
                 },
                 {
                     "name": "selfVolume",

--- a/presets/EnsemblePreset/config.json
+++ b/presets/EnsemblePreset/config.json
@@ -10,7 +10,7 @@
             "options": [
                 {
                     "name": "masterVolume",
-                    "value": 1.5
+                    "value": 1.0
                 },
                 {
                     "name": "selfVolume",

--- a/presets/LargeChoirPreset/config.json
+++ b/presets/LargeChoirPreset/config.json
@@ -10,7 +10,7 @@
             "options": [
                 {
                     "name": "masterVolume",
-                    "value": 1.5
+                    "value": 1.0
                 },
                 {
                     "name": "selfVolume",

--- a/presets/MeetingRoomPreset/config.json
+++ b/presets/MeetingRoomPreset/config.json
@@ -10,7 +10,7 @@
             "options": [
                 {
                     "name": "masterVolume",
-                    "value": 1.5
+                    "value": 1.0
                 },
                 {
                     "name": "selfVolume",

--- a/presets/MusicClassPreset/config.json
+++ b/presets/MusicClassPreset/config.json
@@ -10,7 +10,7 @@
             "options": [
                 {
                     "name": "masterVolume",
-                    "value": 1.5
+                    "value": 1.0
                 },
                 {
                     "name": "selfVolume",

--- a/presets/NoEffectsPreset/config.json
+++ b/presets/NoEffectsPreset/config.json
@@ -10,7 +10,7 @@
             "options": [
                 {
                     "name": "masterVolume",
-                    "value": 1.5
+                    "value": 1.0
                 },
                 {
                     "name": "selfVolume",

--- a/presets/SimpleStagePreset/config.json
+++ b/presets/SimpleStagePreset/config.json
@@ -10,7 +10,7 @@
             "options": [
                 {
                     "name": "masterVolume",
-                    "value": 1.5
+                    "value": 1.0
                 },
                 {
                     "name": "selfVolume",

--- a/presets/SmallChoirPreset/config.json
+++ b/presets/SmallChoirPreset/config.json
@@ -10,7 +10,7 @@
             "options": [
                 {
                     "name": "masterVolume",
-                    "value": 1.5
+                    "value": 1.0
                 },
                 {
                     "name": "selfVolume",

--- a/presets/XLRehearsalRoomPreset/config.json
+++ b/presets/XLRehearsalRoomPreset/config.json
@@ -10,7 +10,7 @@
             "options": [
                 {
                     "name": "masterVolume",
-                    "value": 1.5
+                    "value": 1.0
                 },
                 {
                     "name": "selfVolume",


### PR DESCRIPTION
Using 1.5 makes the studio master clip frequently, which causes audio glitches and is just generally a bad thing.

Also bumping max musicians for default preset to 30 because this should scale much higher after removing the reverb.